### PR TITLE
Adding an _E_xtended grep line for ACM devices

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -13,7 +13,7 @@ Serial = {
 
     this.info( "Board", "Connecting..." );
 
-    child.exec("ls /dev | grep -i usb", function( err, stdout, stderr ) {
+    child.exec("ls /dev | grep -iE 'usb|acm'", function( err, stdout, stderr ) {
       var found,
           usb = stdout.slice( 0, -1 ).split("\n").filter(function( val ) {
             return (/tty/i).test( val );


### PR DESCRIPTION
-E is a POSIX flag for grep that allows extended grep searches. This
 should be portable, although some rough testing might be needed (This
 is part of the POSIX standard, so we should be OK)
