### PR TITLE
Fixed Issue 4 (`current` used as variable name)

### DIFF
--- a/lib/accelerometer.js
+++ b/lib/accelerometer.js
@@ -117,7 +117,7 @@ function Accelerometer( opts ) {
         // TODO: this is sloppy, needs to be cleaned up and
         // and refactored for API consistency
         this.emit( "axischanged", err, {
-          current: this.raw,
+          now: this.raw,
           previous: last
         });
       }


### PR DESCRIPTION
Hey

I've "fixed" issue 4 (`current` used as variable name). I've replaced "current" with "now"..
This breaks backwards compability with scripts that use the "axischanged" event in accelerometer.. It doesn't seem, that this event is used in any tutorials..

/fMads
