### PR TITLE
Piezo - Fixed Issue 4 (`current` used as variable name)

### DIFF
--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -46,16 +46,16 @@ Piezo.prototype.fade = function( fromVol, toVol ) {
   // TODO: Add speed control
   toVol = toVol === 0 ? -1 : toVol;
 
-  var current = fromVol,
+  var now = fromVol,
       step = toVol < fromVol ? -1 : 1;
 
   this.interval = setInterval(function() {
 
-    current = current + step;
+    now = now + step;
 
-    if ( current !== toVol ) {
+    if ( now !== toVol ) {
 
-      this.firmata.analogWrite( this.pin, current );
+      this.firmata.analogWrite( this.pin, now );
     } else {
       // this.firmata.analogWrite( this.pin, 0 );
       clearInterval( this.interval );


### PR DESCRIPTION
Hey

I've fixed issue 4 (`current` used as variable name). I've replaced "current" with "now" in lib/piezo.js in the fade-function..
This shouldn't break any backwards compability..

/fMads
