### PR TITLE
LCD Rewrite

### DIFF
--- a/eg/lcd.js
+++ b/eg/lcd.js
@@ -8,12 +8,12 @@ board.on("ready", function() {
   lcd = new five.LCD({
     // LCD pin name  RS  EN  DB4 DB5 DB6 DB7
     // Arduino pin # 7    8   9   10  11  12
-    pins: [ 7, 8, 9, 10, 11, 12 ]
+    pins: [ 7, 8, 9, 10, 11, 12 ],
+    fourBitMode: true
   });
 
 
-  lcd.write("Hello!");
-
+  lcd.write('Hi! ' + new Date().getTime());
 
   this.repl.inject({
     lcd: lcd

--- a/lib/lcd.js
+++ b/lib/lcd.js
@@ -39,6 +39,7 @@ function LCD( opts ) {
   this.board = Board.mount( opts );
   this.firmata = this.board.firmata;
 
+  this.fourBitMode = opts.fourBitMode;
 
   this.pins = {
     rs: opts.pins[0],
@@ -107,21 +108,41 @@ LCD.prototype.write4Bits = function(value) {
   this.pulse();
 };
 
-
-LCD.prototype.command = function(command /* integer, 0-255 */, callback) {
+LCD.prototype.write8Bits = function(value) {
   var pin = 0;
-  var bitValue;
 
   for (var mask = 128; mask > 0; mask = mask >> 1) {
-    bitValue = this.firmata[ command & mask ? 'HIGH' : 'LOW' ];
-    this.board.digitalWrite( this.pins.data[pin], bitValue );
+    this.board.digitalWrite(
+      this.pins.data[ pin ],
+      this.firmata[ value & mask ? 'HIGH' : 'LOW' ]
+    );
     pin++;
-
-    if (pin === 4) {
-      this.pulse();
-      pin = 0;
-    }
   }
+
+  this.pulse();
+};
+
+LCD.prototype.command = function(command /* integer, 0-255 */, callback) {
+  // var pin = 0;
+  // var bitValue;
+
+  if (this.fourBitMode) {
+    this.write4Bits(command >> 4);
+    this.write4Bits(command);
+  } else {
+    this.write8Bits(command);
+  }
+
+  // for (var mask = 128; mask > 0; mask = mask >> 1) {
+  //   bitValue = this.firmata[ command & mask ? 'HIGH' : 'LOW' ];
+  //   this.board.digitalWrite( this.pins.data[pin], bitValue );
+  //   pin++;
+
+  //   if (pin === 4) {
+  //     this.pulse();
+  //     pin = 0;
+  //   }
+  // }
 
   if ( callback ) {
     process.nextTick(callback);
@@ -155,9 +176,6 @@ LCD.prototype.write = function( message ) {
     this.board.digitalWrite( this.pins.rs, this.firmata.LOW );
   }
 };
-
-
-
 
 LCD.prototype.clear = function() {
   this.command( LCD.CLEARDISPLAY );


### PR DESCRIPTION
- `fourBitMode` option for LCD
- Eliminate need for toBinary module in LCD
- Add `write4Bits` and `write8Bits` methods and use them in initialization and for sending commands
- Use bitwise operators to allow passing numbers, not arrays, to `command` method

ref #32
