### PR TITLE
Removed extra LED constructor & timer var

### DIFF
--- a/eg/motor.js
+++ b/eg/motor.js
@@ -4,14 +4,10 @@ var five = require("../lib/johnny-five.js"),
 board = new five.Board();
 
 board.on("ready", function() {
-  var timer;
-
   // Create a new `motor` hardware instance.
   motor = new five.Motor({
     pin: 5
   });
-
-  (led = new five.Led()).on();
 
   // Inject the `motor` hardware into
   // the Repl instance's context;


### PR DESCRIPTION
The LED constructor is unused and actually barfed on my Raspberry Pi build. I also removed an extra `var timer.`
