### PR TITLE
sonor to not send read event when nothing was read since previous interval.

### DIFF
--- a/lib/sonar.js
+++ b/lib/sonar.js
@@ -51,6 +51,9 @@ function Sonar( opts ) {
 
     err = null;
 
+    // nothing read since previous interval
+    if(samples.length === 0) return;
+
     median = samples.sort()[ Math.floor( samples.length / 2 ) ];
 
     // Emit throttled event


### PR DESCRIPTION
This is a fix for the issue I was having when a sonor's frequency setting was too fast (20 ms or so).
