### PR TITLE
Breaking change to the servo constructor options to fix sensibility of startAt

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -73,10 +73,10 @@ function Servo( opts ) {
   // Allow "setup"instructions to come from
   // constructor options properties
 
-  // If "startAt" true and center falsy
+  // If "startAt" is defined and center is falsy
   // set servo to min or max degrees
-  if ( opts.startAt && !opts.center  ) {
-    this[ opts.startAt ]();
+  if ( opts.startAt !== undefined && !opts.center ) {
+    this.move( opts.startAt );
   }
 
   // If "center" true set servo to 90deg


### PR DESCRIPTION
Breaking change to the servo constructor options. opt.startAt is now a numeric value passed to move();
