### PR TITLE
Allow the user to set a serial port in board options

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -46,93 +46,101 @@ Serial = {
   detect: function( callback ) {
 
     this.info( "Board", "Connecting..." );
-    // TODO:
-    // Confirm bluetooth serial connections
-    // eg. /dev/tty.RN42-1203-SPP-
-    // http://www.rioleo.org/setting-up-the-arduino-pro-mini-and-bluetooth-mate-on-mac.php
-    child.exec( grep, function( err, stdout, stderr ) {
-      var connected, eventType, found, length, ports, usb;
 
-      ports = stdout.slice( 0, -1 ).split("\n").filter(function( val ) {
-        var available = true;
+    if(this.port) {
+      return callback(this.port);
+    } else {
+      // TODO:
+      // Confirm bluetooth serial connections
+      // eg. /dev/tty.RN42-1203-SPP-
+      // http://www.rioleo.org/setting-up-the-arduino-pro-mini-and-bluetooth-mate-on-mac.php
+      child.exec( grep, function( err, stdout, stderr ) {
+        var length, ports;
 
-        // rport regex will test |val| string for either "cu" or "tty",
-        // depending on system:
-        //    darwin: cu
-        //    linux: tty
-        if ( !rport.test(val) ) {
-          available = false;
-        }
+        ports = stdout.slice( 0, -1 ).split("\n").filter(function( val ) {
+          var available = true;
 
-        // Don't allow already used/encountered usb device paths
-        if ( Serial.used.indexOf(val) > -1 ) {
-          available = false;
-        }
-
-        return available;
-      });
-
-      length = ports.length;
-
-      // If no ports are detected when scanning /dev/, then there is
-      // nothing left to do and we can safely exit the program
-      if ( !length ) {
-        // Alert user that no devices were detected
-        this.error( "Board", "No USB devices detected" );
-
-        // Exit the program by sending SIGABRT
-        process.exit(3);
-
-        // Return (not that it matters, but this is a good way
-        // to indicate to readers of the code that nothing else
-        // will happen in this function)
-        return;
-      }
-
-      // Continue with connection routine attempts
-      this.info( "Serial",
-        "Found possible serial port" + ( length > 1 ? "s" : "" ),
-        ports.toString().grey
-      );
-
-      // Get the first available device path from the list of
-      // detected ports
-      usb = ports[0];
-
-      // Add the usb device path to the list of device paths that
-      // are currently in use - this is used by the filter function
-      // above to remove any device paths that we've already encountered
-      // or used to avoid blindly attempting to reconnect on them.
-      Serial.used.push( usb );
-
-      try {
-        found = new Firmata( "/dev/" + usb, function( error ) {
-          if ( error !== undefined ) {
-            err = error;
+          // rport regex will test |val| string for either "cu" or "tty",
+          // depending on system:
+          //    darwin: cu
+          //    linux: tty
+          if ( !rport.test(val) ) {
+            available = false;
           }
 
-          // Execute "ready" callback
-          callback.call( this, err, "ready", found, usb );
-        }.bind(this));
+          // Don't allow already used/encountered usb device paths
+          if ( Serial.used.indexOf(val) > -1 ) {
+            available = false;
+          }
 
-        // Made this far, safely connected
-        connected = true;
-      } catch ( error ) {
-        err = error;
-      }
+          return available;
+        });
 
-      if ( err ) {
-        err = err.message || err;
-      }
+        length = ports.length;
 
-      // Determine the type of event that will be passed on to
-      // the board emitter in the callback passed to Serial.detect(...)
-      eventType = connected ? "connected" : "error";
+        // If no ports are detected when scanning /dev/, then there is
+        // nothing left to do and we can safely exit the program
+        if ( !length ) {
+          // Alert user that no devices were detected
+          this.error( "Board", "No USB devices detected" );
 
-      // Execute "connected" callback
-      callback.call( this, err, eventType, found, usb );
+          // Exit the program by sending SIGABRT
+          process.exit(3);
 
-    }.bind(this));
+          // Return (not that it matters, but this is a good way
+          // to indicate to readers of the code that nothing else
+          // will happen in this function)
+          return;
+        }
+
+        // Continue with connection routine attempts
+        this.info( "Serial",
+          "Found possible serial port" + ( length > 1 ? "s" : "" ),
+          ports.toString().grey
+        );
+
+        // Get the first available device path from the list of
+        // detected ports
+        callback("/dev/" + ports[0]);
+      }.bind(this));
+    }
+  },
+
+  connect: function(usb, callback) {
+    var err, found, connected, eventType;
+
+    // Add the usb device path to the list of device paths that
+    // are currently in use - this is used by the filter function
+    // above to remove any device paths that we've already encountered
+    // or used to avoid blindly attempting to reconnect on them.
+    Serial.used.push( usb );
+
+    try {
+      found = new Firmata( usb, function( error ) {
+        if ( error !== undefined ) {
+          err = error;
+        }
+
+        // Execute "ready" callback
+        callback.call( this, err, "ready", found );
+      }.bind(this));
+
+      // Made this far, safely connected
+      connected = true;
+    } catch ( error ) {
+      err = error;
+    }
+
+    if ( err ) {
+      err = err.message || err;
+    }
+
+    // Determine the type of event that will be passed on to
+    // the board emitter in the callback passed to Serial.detect(...)
+    eventType = connected ? "connected" : "error";
+
+    // Execute "connected" callback
+    callback.call( this, err, eventType, found );
   }
 };
 
@@ -147,6 +155,7 @@ function Board( opts ) {
   opts = opts || {};
 
   var inject = {},
+      self = this,
       keys = Object.keys( opts ),
       key;
 
@@ -154,26 +163,26 @@ function Board( opts ) {
   while ( keys.length ) {
     key = keys.shift();
 
-    this[ key ] = opts[ key ];
+    self[ key ] = opts[ key ];
   }
 
   // Easily track state of hardware
-  this.ready = false;
+  self.ready = false;
 
   // Initialize instance property to reference firmata board
-  this.firmata = null;
+  self.firmata = null;
 
   // Identify for connected hardware cache
-  if ( !this.id ) {
-    this.id = __.uid();
+  if ( !self.id ) {
+    self.id = __.uid();
   }
 
   // If no debug flag, default to false
   // TODO: Remove override
-  this.debug = true;
+  self.debug = true;
 
-  if ( !("debug" in this) ) {
-    this.debug = false;
+  if ( !("debug" in self) ) {
+    self.debug = false;
   }
 
   // Create a Repl instance and store as
@@ -187,67 +196,69 @@ function Board( opts ) {
   //
   if ( Repl.ref ) {
 
-    inject[ this.id ] = this;
+    inject[ self.id ] = self;
 
     Repl.ref.on( "ready", function() {
       Repl.ref.inject( inject );
     });
 
-    this.repl = Repl.ref;
+    self.repl = Repl.ref;
   } else {
-    inject[ this.id ] = inject.board = this;
-    this.repl = new Repl( inject );
+    inject[ self.id ] = inject.board = self;
+    self.repl = new Repl( inject );
   }
 
 
   // Used for testing only
-  if ( this.mock ) {
-    this.firmata = new Firmata( this.mock, function() {
+  if ( self.mock ) {
+    self.firmata = new Firmata( self.mock, function() {
       // Execute "connected" and "ready" callbacks
-      this.emit( "connected", null );
-      this.emit( "ready", null );
-      this.ready = true;
-    }.bind(this));
+      self.emit( "connected", null );
+      self.emit( "ready", null );
+      self.ready = true;
+    }.bind(self));
   } else {
 
-    Serial.detect.call( this, function( err, type, board, port ) {
-      if ( err ) {
-        this.error( "Board", err );
-      } else {
-        // Assign found board to instance
-        this.firmata = board;
-        this.info( "Board " + ( type === "connected" ? "->" : "<-" ) + " Serialport", type, port.grey );
-      }
+    Serial.detect.call( self, function(port) {
+      Serial.connect.call( self, port, function( err, type, board) {
+        if ( err ) {
+          self.error( "Board", err );
+        } else {
+          // Assign found board to instance
+          self.firmata = board;
+          self.info( "Board " + ( type === "connected" ? "->" : "<-" ) + " Serialport", type, port.grey );
+        }
 
-      if ( type === "connected" ) {
-        process.on( "SIGINT", function() {
-          this.warn( "Board", "Closing: firmata, serialport" );
-          // On ^c, make sure we close the process after the
-          // board and serialport are closed. Approx 100ms
-          // TODO: this sucks, need better solution
-          setTimeout(function() {
-            process.exit();
-          }, 100);
-        }.bind(this));
-      }
+        if ( type === "connected" ) {
+          process.on( "SIGINT", function() {
+            self.warn( "Board", "Closing: firmata, serialport" );
+            // On ^c, make sure we close the process after the
+            // board and serialport are closed. Approx 100ms
+            // TODO: this sucks, need better solution
+            setTimeout(function() {
+              process.exit();
+            }, 100);
+          }.bind(self));
+        }
 
-      if ( type === "ready" ) {
-        // Update instance `ready` flag
-        this.ready = true;
+        if ( type === "ready" ) {
+          // Update instance `ready` flag
+          self.ready = true;
 
-        this.port = port;
+          self.port = port;
 
-        // Trigger the repl to start
-        process.stdin.emit( "data", 1 );
-      }
+          // Trigger the repl to start
+          process.stdin.emit( "data", 1 );
+        }
 
-      // emit connect|ready event
-      this.emit( type, err );
+        // emit connect|ready event
+        self.emit( type, err );
+      });
     });
   }
 
   // Cache instance to allow access from module constructors
-  boards.push( this );
+  boards.push( self );
 }
 
 // Inherit event api


### PR DESCRIPTION
I've run into a few issues where the serial port is not properly detected by Johnny-five and right now there is no easy way to set the correct port through the options hash.  I've been [doing something similar](https://github.com/theycallmeswift/BreakfastSerial/blob/master/BreakfastSerial/BreakfastSerial.py#L23) over in BreakfastSerial.

Ex. 

``` javascript
var board = new Board({ port: "/dev/tty.usbfoo1234" });
```

Thoughts?
