### PR TITLE
fix operator precedence error in Servo.center()

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -164,7 +164,7 @@ Servo.prototype.max = function() {
  * @return {[type]} [description]
  */
 Servo.prototype.center = function() {
-  return this.move( Math.abs(((this.range[0] + this.range[1]) / 2)) );
+  return this.move( Math.abs((this.range[0] + this.range[1]) / 2) );
 };
 
 /**


### PR DESCRIPTION
The servo center() function miscalculates center point due to operator precedence error (division is higher than addition).
