### PR TITLE
Default to max speed when leaving out the speed on servo.cw() or servo.ccw()

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -259,6 +259,7 @@ Servo.prototype.stop = function() {
   setup.apis.forEach(function( api ) {
     Servo.prototype[ api ] = function( rate ) {
       var copy = args.slice();
+      rate = rate === undefined ? 1.5 : rate;
 
       if ( this.type !== "continuous" ) {
         this.board.error(


### PR DESCRIPTION
This came up at nodebots
