### PR TITLE
Pitch computations for accelerometer 

### DIFF
--- a/lib/accelerometer.js
+++ b/lib/accelerometer.js
@@ -158,7 +158,7 @@ function Accelerometer( opts ) {
      */
     pitch: {
       get: function() {
-        return Math.abs( Math.atan( this.axis.x, Math.sqrt( Math.pow(this.axis.y, 2) + Math.pow(this.axis.z, 2) ) ) );
+        return Math.abs( Math.atan2( this.axis.x, Math.sqrt( Math.pow(this.axis.y, 2) + Math.pow(this.axis.z, 2) ) ) );
       }
     },
     /**
@@ -168,7 +168,7 @@ function Accelerometer( opts ) {
      */
     roll: {
       get: function() {
-        return Math.abs( Math.atan( this.axis.y, Math.sqrt( Math.pow(this.axis.x, 2) + Math.pow(this.axis.z, 2) ) ) );
+        return Math.abs( Math.atan2( this.axis.y, Math.sqrt( Math.pow(this.axis.x, 2) + Math.pow(this.axis.z, 2) ) ) );
       }
     }
   });


### PR DESCRIPTION
Code currently uses `Math.atan` which accepts only 1 argument and will silently drop the second. What we _want_ is `Math.atan2` which returns the [arctangent of the quotient](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2). See [here](http://www.freescale.com/files/sensors/doc/app_note/AN3461.pdf) for a primer on the math involved. 
