### PR TITLE
Add simple smoother for accelerometer, refactor internals. 

### DIFF
--- a/lib/accelerometer.js
+++ b/lib/accelerometer.js
@@ -49,7 +49,7 @@ function Accelerometer( opts ) {
     return new Accelerometer( opts );
   }
 
-  var pinAxis, last, err, axes, changed, loPass;
+  var pinAxis, last, err, axes, changed;
 
   // axis keys
   axes = ["x", "y", "z"];
@@ -94,6 +94,8 @@ function Accelerometer( opts ) {
   // Blending property for the smoother. Smaller is less filtering
 
   this.alpha = opts.alpha || 0.2;
+
+  this.threshold = opts.threshold || 0.5;
 
   // default smoother is a low pass filter
 
@@ -145,7 +147,7 @@ function Accelerometer( opts ) {
     };
 
     // Check each axis for change above some threshold
-    if ( axisChange( changed , 0.5 ) ) {
+    if ( axisChange( changed , this.threshold ) ) {
       this.emit( "axischange", err, data);
     }
 


### PR DESCRIPTION
This patch adds only an n-1 blending filter (basically a lo-pass filter) and simplifies the output. 

We can see what the smoother looks like here:

![rplot](https://f.cloud.github.com/assets/390863/640177/9797a476-d2ea-11e2-9fa8-d25089e28499.png)

This is not a dramatic change, but future smoothers will allow for more interesting results. 

A rough overview of the other code changes:
- `iranges` have been dropped as they were only used in the `"axischange"` event and that wasn't even fully implemented.
- The initial check is dropped as we initialize `last` with 0s, allowing both the smoother and the change event to be commensurable.
- output data values don't need to be pre-filled with null as we fill them with `analogRead` or `smoother`. Likewise the axis keys are simply supplied. 
