### PR TITLE
Added totalPin mapping for the MEGA

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -679,6 +679,10 @@ Board.Pins.serial = {
     0: true,
     // TX, Transmit
     1: true
+  },
+  MEGA: {
+    0: true,
+    1: true
   }
 };
 
@@ -701,6 +705,9 @@ Board.Pins.spi = {
 // When the pin is HIGH value, the LED is on, when the pin is LOW, it's off.
 Board.Pins.led = {
   UNO: {
+    13: true
+  },
+  MEGA: {
     13: true
   }
 };
@@ -736,7 +743,7 @@ Board.Pins.translations = {
 
 
 Board.Pins.translate = function( pin, type ) {
-  var translations = Board.Pins.translations[ type ];
+  var translations = Board.Pins.translations[ type ] || {};
   return Object.keys( translations ).reduce(function( pin, map ) {
     var p = translations[ map ][ pin ];
     return ( p != null && p ) || pin;


### PR DESCRIPTION
Mapped The totalPins for the mega and fixed crash when `Board.Pins.translations[ type ]` returns undefined.

Used this to map pins, it will make pin mapping easy in future for other boards:

```
five.Board().on("ready", function() {

  var pi = [];
  var pins = this.firmata.pins;

  for ( var i in pins ){

    pi.push( pins[i].supportedModes.length );
  }
  console.log( pi );

});
```
