### PR TITLE
switch to temporal implementation

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -426,11 +426,11 @@ Object.keys( Board.prototype.log.types ).forEach(function( type ) {
  * Pass through methods to temporal
  */
 [
-  "delay",
-  "loop", "queue"
+  "delay", "loop", "queue"
 ].forEach(function( method ) {
   Board.prototype[ method ] = function( time, callback ) {
     temporal[ method ]( time, callback );
+    return this;
   };
 });
 


### PR DESCRIPTION
Temporal was already included in johnny-five's dependencies.

Switched `Board.wait` and `Board.loop` to pass through to `temporal.delay` and `temporal.loop` instead of `setTimeout`/`setInterval`

Added `Board.delay` and `Board.queue` to also pass through to temporal. (`Board.wait` is an alias of `Board.delay` now).
