### PR TITLE
Update the README to warn beginners not to run j5 in the REPL

### DIFF
--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -75,6 +75,7 @@ board.on("ready", function() {
 
 #### [Watch it here!](http://jsfiddle.net/rwaldron/dtudh/show/light)
 
+Note: Node will crash if you try to run johnny-five in the node REPL, but board instances will create their own contextual REPL. Put your script in a file.
 
 ## More Input
 


### PR DESCRIPTION
Not sure if that's the best place for the warning, but it would have saved me some confusion. Alternatively as a comment in the example code?
