### PR TITLE
Deprecated Ping's "read"

### DIFF
--- a/lib/ping.js
+++ b/lib/ping.js
@@ -63,8 +63,11 @@ function Ping( opts ) {
     if ( !median ) {
       median = last;
     }
-    // Emit throttled event
+    // @DEPRECATED!!!
     this.emit( "read", err, median );
+
+    // Emit the continuous "data" event
+    this.emit( "data", err, median );
 
     // If the median value for this interval is not the same as the
     // median value in the last interval, fire a "change" event.


### PR DESCRIPTION
Deprecated `read` in favour of `data` to align with Sensor. https://github.com/rwldrn/johnny-five/issues/195
