### PR TITLE
Spy on all firmata calls made in tests

### DIFF
--- a/test/board.js
+++ b/test/board.js
@@ -176,6 +176,8 @@ exports["fn"] = {
   }
 };
 
+// TODO: need tests for board.shiftOut
+
 // TODO: need mock firmata object
 // exports["modules"] = {
 //   "optional-new": function( test ) {

--- a/test/mock-serial.js
+++ b/test/mock-serial.js
@@ -10,7 +10,7 @@ var MockSerialPort = function( path ) {
 util.inherits( MockSerialPort, events.EventEmitter );
 
 MockSerialPort.prototype.write = function( buffer ) {
-  this.lastWrite = buffer;
+  // this.lastWrite = buffer;
 };
 
 MockSerialPort.prototype.close = function() {

--- a/test/pin.js
+++ b/test/pin.js
@@ -128,10 +128,10 @@ exports["Pin"] = {
 
 
     this.analog.write(1023);
-    test.deepEqual( serial.lastWrite, [ 225, 127, 7 ] );
+    test.ok(this.analogSpy.calledWith(1, 1023));
 
     this.analog.write(0);
-    test.deepEqual( serial.lastWrite, [ 225, 0, 0 ] );
+    test.ok(this.analogSpy.calledWith(1, 0));
 
     test.done();
   },


### PR DESCRIPTION
Spy on all firmata calls instead of looking at the midi serial data. This works around the change in firmata's `write` format (from arrays to buffers). Should fix #225 
