### PR TITLE
MockFirmata

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -239,6 +239,13 @@ function Board( opts ) {
     // Execute "connected" and "ready" callbacks
     this.emit( "connected", null );
     this.emit( "ready", null );
+  } else if ( opts.firmata ) {
+    // If you already have a connected firmata instance
+    this.firmata = opts.firmata;
+    this.ready = true;
+    this.pins = Board.Pins( this );
+    this.emit( "connected", null );
+    this.emit( "ready", null );
   } else {
 
     Serial.detect.call( this, function( port ) {

--- a/test/led.js
+++ b/test/led.js
@@ -1,29 +1,18 @@
-var SerialPort = require("./mock-serial").SerialPort,
-    pins = require("./mock-pins"),
-    five = require("../lib/johnny-five.js"),
-    Board = five.Board,
-    Led = five.Led,
-    sinon = require("sinon");
+var five = require("../lib/johnny-five.js"),
+    sinon = require("sinon"),
+    MockFirmata = require("./mock-firmata"),
+    Led = five.Led;
 
-function createNewBoard() {
-  var serial = new SerialPort("/path/to/fake/usb"),
-      board = new five.Board({
-        repl: false,
-        debug: true,
-        mock: serial
-      });
-
-  board.firmata.pins = pins.UNO;
-  board.firmata.analogPins = [ 14, 15, 16, 17, 18, 19 ];
-  board.pins = Board.Pins( board );
-  return board;
+function newBoard() {
+  return new five.Board({
+    firmata: new MockFirmata(),
+    repl: false
+  });
 }
-
-// END
 
 exports["Led - Digital"] = {
   setUp: function( done ) {
-    this.board = createNewBoard();
+    this.board = newBoard();
     this.spy = sinon.spy( this.board.firmata, "digitalWrite" );
 
     this.led = new Led({ pin: 13, board: this.board });
@@ -127,7 +116,7 @@ exports["Led - Digital"] = {
 
 exports["Led - PWM (Analog)"] = {
   setUp: function( done ) {
-    this.board = createNewBoard();
+    this.board = newBoard();
     this.spy = sinon.spy(this.board.firmata, "analogWrite");
 
     this.led = new Led({ pin: 11, board: this.board });
@@ -249,7 +238,7 @@ exports["Led - PWM (Analog)"] = {
 exports["Led.RGB"] = {
 
   setUp: function( done ) {
-    this.board = createNewBoard();
+    this.board = newBoard();
 
     this.ledRgb = new Led.RGB({
       pins: {

--- a/test/mock-firmata.js
+++ b/test/mock-firmata.js
@@ -1,0 +1,27 @@
+var util = require("util"),
+    events = require("events"),
+    pins = require("./mock-pins");
+
+function MockFirmata( opt ) {
+  opt = opt || {};
+  this.pins = opt.pins || pins.UNO;
+  this.analogPins = opt.analogPins || pins.UNOANALOG;
+  this.MODES = {
+    INPUT: 0x00,
+    OUTPUT: 0x01,
+    ANALOG: 0x02,
+    PWM: 0x03,
+    SERVO: 0x04
+  };
+  this.HIGH = 1;
+  this.LOW = 0;
+  this.firmware = {};
+}
+
+util.inherits( MockFirmata, events.EventEmitter );
+
+MockFirmata.prototype.digitalWrite = function() { };
+MockFirmata.prototype.analogWrite = function() { };
+MockFirmata.prototype.pinMode = function() { };
+
+module.exports = MockFirmata;

--- a/test/mock-pins.js
+++ b/test/mock-pins.js
@@ -1,3 +1,5 @@
+module.exports.UNOANALOG = [ 14, 15, 16, 17, 18, 19 ];
+
 module.exports.UNO = [
 { supportedModes: [],
   mode: 1,


### PR DESCRIPTION
This is my first pass at creating and using a mock Firmata object. It passes all tests for `led.js` and should be extended as needed for other tests. It uses the UNO pins from `mock-pins.js`.

In order to use this object I had to modify Board() to allow passing in a firmata object. The object should be connected and ready to go before constructing the Johnny-Five `Board()`.
