### PR TITLE
Use johnny-five with boards other than Arduino/Firmata

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -1,13 +1,13 @@
 var events = require("events"),
     util = require("util"),
     colors = require("colors"),
-    Firmata = require("firmata").Board,
     _ = require("lodash"),
     __ = require("../lib/fn.js"),
     Repl = require("../lib/repl.js"),
     serialport = require("serialport"),
     Pins = require("../lib/board.pins.js"),
     Options = require("../lib/board.options.js"),
+    FirmataIOBoard = require("firmata-ioboard"),
     // temporal = require("temporal"),
     board,
     boards,
@@ -105,7 +105,7 @@ Serial = {
     }.bind(this));
   },
 
-  connect: function( usb, callback ) {
+  connect: function( usb, factory, callback ) {
     var err, found, connected, eventType;
 
     // Add the usb device path to the list of device paths that
@@ -115,7 +115,7 @@ Serial = {
     Serial.used.push( usb );
 
     try {
-      found = new Firmata( usb, function( error ) {
+      found = factory.call( this, usb, function( error ) {
         if ( error !== undefined ) {
           err = error;
         }
@@ -192,6 +192,11 @@ function Board( opts ) {
     this.repl = true;
   }
 
+  // if no IOBoard factory has been set, default to Firmata
+  if ( !("factory" in this) ) {
+    this.factory = FirmataIOBoard;
+  }
+
   // Specially processed pin capabilities object
   // assigned when board is initialized and ready
   this.pins = null;
@@ -228,7 +233,7 @@ function Board( opts ) {
   // Used for testing only
   if ( this.mock ) {
     this.ready = true;
-    this.firmata = new Firmata( this.mock, function() {} );
+    this.firmata = new FirmataIOBoard( this.mock );
 
     // NEED A DUMMY OF THE PINS OBJECT
     //
@@ -241,15 +246,14 @@ function Board( opts ) {
     this.emit( "ready", null );
   } else if ( opts.firmata ) {
     // If you already have a connected firmata instance
-    this.firmata = opts.firmata;
+    this.firmata = new FirmataIOBoard( opts.firmata );
     this.ready = true;
     this.pins = Board.Pins( this );
     this.emit( "connected", null );
     this.emit( "ready", null );
   } else {
-
     Serial.detect.call( this, function( port ) {
-      Serial.connect.call( this, port, function( err, type, firmata ) {
+      Serial.connect.call( this, port, this.factory, function( err, type, firmata ) {
         if ( err ) {
           this.error( "Board", err );
         } else {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   },
   "dependencies": {
     "colors": ">=0.5.1",
-    "firmata": ">=0.2.9",
     "lodash": ">=0.1.0",
     "es6-collections": ">=0.0.1",
     "socket.io": "latest",
@@ -86,7 +85,8 @@
     "serialport": "latest",
     "optimist": "~0.5.2",
     "async": "~0.2.9",
-    "keypress": "latest"
+    "keypress": "latest",
+    "firmata-ioboard": "~1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/test/board.js
+++ b/test/board.js
@@ -4,6 +4,7 @@ var SerialPort = require("./mock-serial").SerialPort,
     __ = require("../lib/fn.js"),
     _ = require('lodash'),
     MockFirmata = require("./mock-firmata"),
+	FirmataIOBoard = require("firmata-ioboard"),
     board = new five.Board({
       repl: false,
       firmata: new MockFirmata()
@@ -150,7 +151,7 @@ exports["instance"] = {
 
   "firmata": function( test ) {
     test.expect(1);
-    test.ok( board.firmata instanceof MockFirmata );
+    test.ok( board.firmata instanceof FirmataIOBoard );
     test.done();
   },
 


### PR DESCRIPTION
Johnny-Five is an awesome library, but I'd really like to be able to use the API to talk to boards that aren't Arduino/Firmata.

This pull request removes the dependency on Firmata, instead inserting a [facade](https://npmjs.org/package/ioboard) that looks to the rest of the code just like Firmata.  You can see the beginnings of such a facade [here](https://npmjs.org/package/pololu-maestro-ioboard).

To use the facade, you'd do this sort of thing:

``` javascript
var five = require("johnny-five"),
  MaestroIOBoard = require("maestro-ioboard");

var board = new five.Board({factory: MaestroIOBoard});
```

It's fully backwards compatible, so if you don't want to use the factory option, you can still use the no-args constructor:

``` javascript
var five = require("johnny-five");

var board = new five.Board();
```

This will use the [firmata-ioboard](https://npmjs.org/package/firmata-ioboard) facade instead which is just a bunch of pass-throughs to firmata.

Alternatively you can still manually create a firmata instance and pass it in:

``` javascript
var five = require("johnny-five"),
  Firmata = require("firmata").board;

var firmata = new Firmata("/some/port", {}, function() {});
var board = new five.Board({firmata: firmata});
```

I did consider implementing the Firmata protocol for the Pololu Maestro, but sadly in order to send data back to the controlling computer, you need to use two serial ports (one for input and one for output) so it won't work with the firmata node module as it stands.

Anyway, I'd love to know what you think.
