### PR TITLE
Adds support for digital LEDs in brightness method

### DIFF
--- a/lib/led.js
+++ b/lib/led.js
@@ -157,19 +157,26 @@ Led.prototype.toggle = function() {
 Led.prototype.brightness = function( value ) {
   var state = priv.get( this );
 
-  // If pin is not a PWM pin, emit an error
-  if ( !this.board.pins.isPwm(this.pin) ) {
+  if ( this.board.pins.isPwm(this.pin) ) {
+    // Reset pinMode to PWM
+    this.pinMode = this.firmata.MODES.PWM;
+
+    this.firmata.analogWrite( this.pin, value );
+  } else if ( this.board.pins.isDigital(this.pin) ) {
+    if ( value !== 0 && value !== 255 ) {
+      this.board.warn( "Led", value + " was passed to Led.brightness for pin " + this.pin + " but the pin is not in PWM mode" );
+    }
+
+    this.pinMode = this.firmata.MODES.OUTPUT;
+
+    this.firmata.digitalWrite( this.pin, value ? this.firmata.HIGH : this.firmata.LOW );
+  } else {
     Board.Pins.Error({
       pin: this.pin,
-      type: "PWM",
-      via: "Led",
+      type: "PWM or digital output",
+      via: "Led"
     });
   }
-
-  // Reset pinMode to PWM
-  this.pinMode = this.firmata.MODES.PWM;
-
-  this.firmata.analogWrite( this.pin, value );
 
   state.value = value;
 

--- a/test/led.js
+++ b/test/led.js
@@ -110,6 +110,22 @@ exports["Led - Digital"] = {
     test.expect(1);
     test.equal( this.led.blink, this.led.strobe );
     test.done();
+  },
+
+  brightness: function( test ) {
+    test.expect(3);
+
+    this.led.off();
+    this.led.brightness(255);
+    test.ok( this.spy.calledWith(13, this.board.firmata.HIGH) );
+
+    this.led.brightness(100);
+    test.ok( this.spy.calledWith(13, this.board.firmata.HIGH) );
+
+    this.led.brightness(0);
+    test.ok( this.spy.calledWith(13, this.board.firmata.LOW) );
+
+    test.done();
   }
 };
 


### PR DESCRIPTION
I've got some RGB LEDs which are connected to digital out pins.  Setting colours like "FF0000" and "00FF00" use the brightness method in led.js which currently baulks if the LED pin is not in PWM mode.

This pull request allows digital outputs to be used, however if the brightness value being written to a digital output is not 0 or 255 it will emit a warning in the log.
