### PR TITLE
Allow new device type to be passed as an object

### DIFF
--- a/lib/distance.js
+++ b/lib/distance.js
@@ -41,7 +41,12 @@ function Distance(opts) {
 
   Sensor.call(this, opts);
 
-  var device = Devices[opts.device];
+  var device;
+  if (typeof opts.device === "string") {
+    device = Devices[opts.device];
+  } else {
+    device = opts.device;
+  }
 
   if (device) {
     if (!device.inches) {


### PR DESCRIPTION
An example use case for this would be a new IR Sensor device is released (better range) but has not been added to Johnny-Five. Until it is added an experienced user could:

```
distance = new five.Distance( { pin: "A2", device: {
  // Our new distance device type
  cm: {
    get: function() {
      return +(14650.08 * Math.pow(this.raw, -0.935) - 10).toFixed(2);
    }
  }
});
```
