### PR TITLE
Transition rate option added to Servo.to() method

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -135,11 +135,12 @@ util.inherits(Servo, events.EventEmitter);
  *
  * @param  {Number} degrees   Degrees to turn servo to.
  * @param  {Number} time      Time to spend in motion.
+ * @param  {Number} rate      The rate of the motion transiton
  *
  * @return {Servo} instance
  */
 
-Servo.prototype.to = function(degrees, time) {
+Servo.prototype.to = function(degrees, time, rate) {
 
   // Enforce limited range of motion
   degrees = Board.constrain(degrees, this.range[0], this.range[1]);
@@ -162,13 +163,13 @@ Servo.prototype.to = function(degrees, time) {
   var history = priv.get(this).history;
 
   if (typeof time !== "undefined") {
-
+    rate = rate || 100; // Default to 100
     last = this.last && this.last.degrees || 0;
     distance = Math.abs(last - degrees);
     percent = 0;
 
     if (this.interval) {
-      clearImmediate(this.interval);
+      clearInterval(this.interval);
     }
 
     if (degrees < last) {
@@ -176,7 +177,7 @@ Servo.prototype.to = function(degrees, time) {
     }
 
     this.interval = setInterval(function() {
-      var delta = ++percent * (distance / 100);
+      var delta = ++percent * (distance / rate);
 
       if (isReverse) {
         delta *= -1;
@@ -189,11 +190,11 @@ Servo.prototype.to = function(degrees, time) {
         degrees: last + delta
       });
 
-      if (percent === 100) {
+      if (percent === rate) {
         this.emit("move:complete");
         clearInterval(this.interval);
       }
-    }.bind(this), time / 100);
+    }.bind(this), time / rate);
 
   } else {
 


### PR DESCRIPTION
Added the option to be able to set a transition rate, which is basically the amount of steps the distance (last - current) is broken down to (default is 100). Helpful to reduce the amount of data processed when small angle change is the case.
