### PR TITLE
Implement board detection

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -1,5 +1,6 @@
 var Emitter = require("events").EventEmitter,
   util = require("util"),
+  fs = require("fs"),
   os = require("os"),
   colors = require("colors"),
   _ = require("lodash"),
@@ -13,20 +14,31 @@ var Emitter = require("events").EventEmitter,
 
 // Environment setup
 
-// Currently, the only on-board environment supported is
-// the Intel Galileo which is identifiable by the name "yocto".
-// As more of these "execute from device" environments emerge,
-// this approach will have to be refactored.
-var isOnBoard = os.release().indexOf("yocto") !== -1;
+var boardType = detectBoard();
+var isOnBoard = typeof boardType !== "undefined";
 var boards = [];
 var rport = /usb|acm|^com/i;
 var port = "";
 
 if (isOnBoard) {
-  IO = require("galileo-io");
+  IO = require(boardType + "-io");
 } else {
   IO = require("firmata").Board;
   serialport = require("serialport");
+}
+
+
+function detectBoard() {
+  var board;
+
+  if (os.release().indexOf("yocto") !== -1) {
+    board = "galileo";
+  } else if (os.arch() === "arm" &&
+             fs.existsSync("/sys/devices/bone_capemgr.8/baseboard/board-name")) {
+    board = "beaglebone";
+  }
+
+  return board;
 }
 
 /**


### PR DESCRIPTION
After checking `bonescript` source code we can know if we are running on a beaglebone checking if `/sys/devices/bone_capemgr.8/baseboard/board-name` exists.
