### PR TITLE
Fix for LED status isOn()

### DIFF
--- a/lib/led.js
+++ b/lib/led.js
@@ -289,8 +289,11 @@ Led.prototype.fade = function(val, time) {
       if ((direction > 0 && valueAt === 255) ||
         (direction < 0 && valueAt === 0) ||
         valueAt === val) {
+        // if the direction is up, and we're at the top, don't call stop, keep the LED 'on'
+        if(!(direction > 0 && valueAt === 255)){
+            this.stop();
+        }
 
-        this.stop();
       } else {
         this.io.analogWrite(
           this.pin, valueAt + direction


### PR DESCRIPTION
I came across this today, when calling LED.fadeIn(), the LED.isOn() status is incorrect.  What I found was that LED.stop() is being called on fadeIn and fadeOut operations, setting the status to false.  What I did here  was a quick fix during the fade() to insure that if the direction is 'up' and the value is 255, that we will leave the LED status as 'on' or true.

Let me know if there is anything missing.
