### PR TITLE
generate led-rgb docs

### DIFF
--- a/docs/led-rgb.md
+++ b/docs/led-rgb.md
@@ -32,12 +32,14 @@ five.Board().on("ready", function() {
 ```
 
 
-
 ## Breadboard/Illustration
 
 
-![docs/breadboard/led-rgb-anode.png](breadboard/led-rgb.png)
-[docs/breadboard/led-rgb-anode.fzz](breadboard/led-rgb.fzz)
+![docs/breadboard/led-rgb.png](breadboard/led-rgb.png)
+[docs/breadboard/led-rgb.fzz](breadboard/led-rgb.fzz)
+
+
+
 
 
 


### PR DESCRIPTION
Fixing manually edited led-rgb doc that had a typo, now auto-generated using grunt
