### PR TITLE
Arguments to Led.RGB not passed correctly

### DIFF
--- a/lib/led.js
+++ b/lib/led.js
@@ -636,7 +636,7 @@ Led.RGB.prototype.off = function() {
     var args = [].slice.call(arguments);
 
     Led.RGB.colors.forEach(function(color) {
-      this[color][method](args);
+      this[color][method].apply(this[color], args);
     }, this);
 
     return this;


### PR DESCRIPTION
Now uses apply()
