### PR TITLE
Missing blink alias for Led.RGB and Led.Array

### DIFF
--- a/lib/led.js
+++ b/lib/led.js
@@ -488,6 +488,7 @@ Led.Array.prototype.each = function(callbackFn) {
   };
 });
 
+Led.Array.prototype.blink = Led.Array.prototype.strobe;
 
 /**
  * Led.RGB
@@ -643,6 +644,6 @@ Led.RGB.prototype.off = function() {
   };
 });
 
-
+Led.RGB.prototype.blink = Led.RGB.prototype.strobe;
 
 module.exports = Led;

--- a/test/led.js
+++ b/test/led.js
@@ -506,6 +506,8 @@ exports["Led.RGB"] = {
     }, {
       name: "strobe"
     }, {
+      name: "blink"
+    }, {
       name: "stop"
     }];
 
@@ -595,6 +597,12 @@ exports["Led.RGB"] = {
     test.ok(this.analog.calledWith(11, 0));
 
     test.done();
+  },
+
+  blink: function(test) {
+    test.expect(1);
+    test.equal(this.ledRgb.blink, this.ledRgb.strobe);
+    test.done();
   }
 
 };
@@ -643,6 +651,8 @@ exports["Led.RGB - Common Anode"] = {
       name: "fadeOut"
     }, {
       name: "strobe"
+    }, {
+      name: "blink"
     }, {
       name: "stop"
     }];
@@ -712,6 +722,12 @@ exports["Led.RGB - Common Anode"] = {
     this.ledRgb.off();
     test.ok(this.spy.calledWith(11, 255));
 
+    test.done();
+  },
+
+  blink: function(test) {
+    test.expect(1);
+    test.equal(this.ledRgb.blink, this.ledRgb.strobe);
     test.done();
   }
 


### PR DESCRIPTION
Regular Led sets blink==strobe, so we should probably be consistent on RGB and Array.
