### PR TITLE
Improve performance by removing dynamic logging aliases

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -497,15 +497,18 @@ Board.prototype.log.types = {
 };
 
 // Make shortcuts to all logging methods
-Object.keys(Board.prototype.log.types).forEach(function(type) {
-  Board.prototype[type] = function() {
-    var args = [].slice.call(arguments);
-    args.unshift(type);
-
-    this.log.apply(this, args);
-  };
-});
-
+Board.prototype.error = function(module, message) {
+  this.log('error', module, message);
+};
+Board.prototype.fail = function(module, message) {
+  this.log('fail', module, message);
+};
+Board.prototype.warn = function(module, message) {
+  this.log('warn', module, message);
+};
+Board.prototype.info = function(module, message) {
+  this.log('info', module, message);
+};
 
 /**
  * delay, loop, queue


### PR DESCRIPTION
When using Johnny five for a certain amount of time the processor high up to 100% because of the dynamic logging function. We can remove it to improve performances which removes the modularity which is anyway imho not very useful
