### PR TITLE
Fix goofy call to start()

### DIFF
--- a/lib/motor.js
+++ b/lib/motor.js
@@ -28,7 +28,7 @@ var Devices = {
     },
     release: {
       value: function() {
-        this.start();
+        this.resume();
         this.emit("release", null, new Date());
       }
     }
@@ -92,9 +92,8 @@ var Devices = {
           this.io.digitalWrite(this.pins.brake, 0);
           this.io.digitalWrite(this.pins.dir, this.direction);
 
-          var speed = this.speed();
+          this.resume();
 
-          this.speed(speed);
           this.emit("release", null, new Date());
         }
 
@@ -155,8 +154,7 @@ var Devices = {
     release: {
       value: function() {
 
-        var speed = this.speed();
-        this.speed(speed);
+        this.resume();
 
         this.io.digitalWrite(this.pins.dir, this.direction);
         this.io.digitalWrite(this.pins.cdir, 1 ^ this.direction);
@@ -427,6 +425,14 @@ Motor.prototype.stop = function() {
 
   // "stop" event is fired when the motor is stopped
   this.emit("stop", null, new Date());
+
+  return this;
+};
+
+Motor.prototype.resume = function() {
+
+  var speed = this.speed();
+  this.speed(speed);
 
   return this;
 };

--- a/test/motor.js
+++ b/test/motor.js
@@ -31,6 +31,8 @@ exports["Motor: Non-Directional"] = {
       name: "stop"
     }, {
       name: "speed"
+    }, {
+      name: "resume"
     }];
 
     this.instance = [{
@@ -137,6 +139,8 @@ exports["Motor: Directional"] = {
       name: "start"
     }, {
       name: "stop"
+    }, {
+      name: "resume"
     }];
 
     this.instance = [{
@@ -303,6 +307,8 @@ exports["Motor: Directional with no speed passed"] = {
       name: "start"
     }, {
       name: "stop"
+    }, {
+      name: "resume"
     }];
 
     this.instance = [{
@@ -396,6 +402,8 @@ exports["Motor: Directional with Brake"] = {
       name: "brake"
     }, {
       name: "release"
+    }, {
+      name: "resume"
     }];
 
     this.instance = [{
@@ -596,6 +604,8 @@ exports["Motor: Directional with Current Sensing Pin"] = {
       name: "brake"
     }, {
       name: "release"
+    }, {
+      name: "resume"
     }];
 
     this.instance = [{
@@ -669,6 +679,8 @@ exports["Motor: Directional - Three Pin"] = {
       name: "reverse"
     }, {
       name: "rev"
+    }, {
+      name: "resume"
     }];
 
     this.instance = [{
@@ -812,6 +824,8 @@ exports["Motor: Inverse Speed When Forward"] = {
       name: "reverse"
     }, {
       name: "rev"
+    }, {
+      name: "resume"
     }];
 
     this.instance = [{
@@ -964,6 +978,8 @@ exports["Motor: Inverse Speed With Brake"] = {
       name: "reverse"
     }, {
       name: "rev"
+    }, {
+      name: "resume"
     }];
 
     this.instance = [{


### PR DESCRIPTION
This was highlighted by tableflip/nodebot-workshop#9 and
nodeschool/discussions#398 and fixes those issues. Added new method
resume() which resumes the motor’s last set speed instead of depending
on start().
