### PR TITLE
Piezo fixes for #413

### DIFF
--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -178,10 +178,9 @@ function parseBeat(note) {
 Piezo.prototype.tone = function(tone, duration) {
   if (isNaN(tone) || isNaN(duration)) {
     // Very Bad Things happen if one tries to play a NaN tone
-    if (this.board.debug) {
-      console.warn('Piezo.prototype.tone: Skipping invalid tone, duration: ', tone, duration);
-    }
-    return false;
+    throw new Error(
+      "Piezo.tone: invalid tone or duration"
+    );
   }
 
   clearTimer.call(this);

--- a/test/piezo.js
+++ b/test/piezo.js
@@ -221,14 +221,20 @@ exports["Piezo"] = {
       ["ding", "dong"],
       ["c4", "zimple"],
       ["?", 'foof']
-      // ["C4", 1][null, 1/2] Original bad value; jshint won't allow
+    //  ["C4", 1][null, 1/2] // Original bad value; jshint won't allow
     ];
     test.expect(lameValues.length);
     lameValues.forEach(function(element) {
-      var fail = this.piezo.tone(element[0], element[1]);
-      test.strictEqual(fail, false);
+      try {
+        if (element && element.length) {
+          this.piezo.tone(element[0], element[1]);
+        } else {
+          this.piezo.tone(element);
+        }
+      } catch (e) {
+        test.equal(e.message, "Piezo.tone: invalid tone or duration");
+      }
     }, this);
-
     test.done();
   },
 


### PR DESCRIPTION
`Piezo.prototype.tone` will not try to play `NaN` tones anymore, preventing piercing grief.

Note that the tests I added couldn't include the original offending wonky array syntax; `jshint` won't allow it. I did add a test for it at one point and ran the `nodeunit` grunt task by itself and it passed.
