### PR TITLE
Adafruit Motor Shield V2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ board.on("ready", function() {
 - [Motor Brake](https://github.com/rwldrn/johnny-five/blob/master/docs/motor-brake.md)
 - [Motor Current](https://github.com/rwldrn/johnny-five/blob/master/docs/motor-current.md)
 - [Motor Hbridge](https://github.com/rwldrn/johnny-five/blob/master/docs/motor-hbridge.md)
+- [Motor PCA9685](https://github.com/rwldrn/johnny-five/blob/master/docs/motor-PCA9685.md)
 - [Motor 3 Pin](https://github.com/rwldrn/johnny-five/blob/master/docs/motor-3-pin.md)
 - [Motobot](https://github.com/rwldrn/johnny-five/blob/master/docs/motobot.md)
 

--- a/docs/motor-PCA9685.md
+++ b/docs/motor-PCA9685.md
@@ -1,0 +1,74 @@
+# Motor PCA9685
+
+Run with:
+```bash
+node eg/motor-PCA9685.js
+```
+
+
+```javascript
+var five = require("johnny-five"),
+  board, motor, led;
+
+board = new five.Board();
+
+/*
+ * The PCA9685 controller has been test on
+ * the Adafruit Motor/Stepper/Servo Shield v2
+*/
+
+board.on("ready", function() {
+  // Create a new `motor` hardware instance.
+  motor = new five.Motor({
+    pins: [ 8, 9, 10 ],
+    controller: "PCA9685",
+    address: 0x60
+  });
+
+  // Inject the `motor` hardware into
+  // the Repl instance's context;
+  // allows direct command line access
+  board.repl.inject({
+    motor: motor,
+  });
+
+  // Motor Event API
+
+  // "start" events fire when the motor is started.
+  motor.on("start", function(err, timestamp) {
+    console.log("start", timestamp);
+
+    // Demonstrate motor stop in 2 seconds
+    board.wait(2000, function() {
+      motor.stop();
+    });
+  });
+
+  // "stop" events fire when the motor is started.
+  motor.on("stop", function(err, timestamp) {
+    console.log("stop", timestamp);
+  });
+
+  // Motor API
+
+  // start()
+  // Start the motor. `isOn` property set to |true|
+  motor.start();
+
+});
+
+```
+
+
+
+
+
+
+
+
+
+## License
+Copyright (c) 2012-2013 Rick Waldron <waldron.rick@gmail.com>
+Licensed under the MIT license.
+Copyright (c) 2014 The Johnny-Five Contributors
+Licensed under the MIT license.

--- a/docs/motor-hbridge.md
+++ b/docs/motor-hbridge.md
@@ -11,7 +11,7 @@ node eg/motor-hbridge.js
   IMPORTANT!!! This example is not intended for off the shelf
   H-Bridge based motor controllers. It is for home made H-Bridge
   controllers. Off the shelf controllers abstract away the need
-  to invert the PWM (AKA Speed) value when the direction pin is set 
+  to invert the PWM (AKA Speed) value when the direction pin is set
   to high. This is for controllers that do not have that feature.
 */
 

--- a/eg/motor-PCA9685.js
+++ b/eg/motor-PCA9685.js
@@ -1,0 +1,49 @@
+var five = require("../lib/johnny-five.js"),
+  board, motor, led;
+
+board = new five.Board();
+
+/*
+ * The PCA9685 controller has been test on
+ * the Adafruit Motor/Stepper/Servo Shield v2
+*/
+
+board.on("ready", function() {
+  // Create a new `motor` hardware instance.
+  motor = new five.Motor({
+    pins: [ 8, 9, 10 ],
+    controller: "PCA9685",
+    address: 0x60
+  });
+
+  // Inject the `motor` hardware into
+  // the Repl instance's context;
+  // allows direct command line access
+  board.repl.inject({
+    motor: motor,
+  });
+
+  // Motor Event API
+
+  // "start" events fire when the motor is started.
+  motor.on("start", function(err, timestamp) {
+    console.log("start", timestamp);
+
+    // Demonstrate motor stop in 2 seconds
+    board.wait(2000, function() {
+      motor.stop();
+    });
+  });
+
+  // "stop" events fire when the motor is started.
+  motor.on("stop", function(err, timestamp) {
+    console.log("stop", timestamp);
+  });
+
+  // Motor API
+
+  // start()
+  // Start the motor. `isOn` property set to |true|
+  motor.start();
+
+});

--- a/eg/motor-hbridge.js
+++ b/eg/motor-hbridge.js
@@ -2,7 +2,7 @@
   IMPORTANT!!! This example is not intended for off the shelf
   H-Bridge based motor controllers. It is for home made H-Bridge
   controllers. Off the shelf controllers abstract away the need
-  to invert the PWM (AKA Speed) value when the direction pin is set 
+  to invert the PWM (AKA Speed) value when the direction pin is set
   to high. This is for controllers that do not have that feature.
 */
 

--- a/lib/motor.js
+++ b/lib/motor.js
@@ -5,6 +5,90 @@ var Board = require("../lib/board.js"),
 
 var priv = new Map();
 
+function nanosleep(ns) {
+  var start = process.hrtime();
+  while (process.hrtime() < start + ns) {}
+}
+
+var Controllers = {
+  PCA9685: {
+    COMMANDS: {
+      value: {
+        PCA9685_MODE1: 0x0,
+        PCA9685_PRESCALE: 0xFE,
+        LED0_ON_L: 0x6
+      }
+    },
+    address: {
+      get: function() {
+        return this.opts.address;
+      }
+    },
+    setPWM: {
+      value: function( pin, off, on) {
+        if (typeof on === "undefined") {
+          on = 0;
+        }
+        on *= 16;
+        off *= 16;
+        this.io.sendI2CWriteRequest(this.opts.address, [ this.COMMANDS.LED0_ON_L + 4 * (pin), on, on>>8, off, off>>8] );
+      }
+    },
+    setPin: {
+      value: function( pin, value, duty, phaseShift ) {
+        var on = 0;
+
+        if (value !== 0) {
+          value = 255;
+        }
+
+        if (typeof duty !== "undefined") {
+          value = duty;
+        }
+
+        if (typeof phaseShift !== "undefined") {
+          on = phaseShift;
+          value = value + on;
+        }
+
+        this.setPWM(pin, value, on);
+
+      }
+    },
+    initialize: {
+      value: function(opts) {
+
+        if (!Board.Drivers) {
+          Board.Drivers = {};
+        }
+
+        if (!Board.Drivers[this.opts.address]) {
+          this.io.sendI2CConfig();
+          Board.Drivers[this.opts.address] = {
+            initialized: false
+          };
+
+          this.io.sendI2CWriteRequest(this.opts.address, [this.COMMANDS.PCA9685_MODE1, 0x0] ); // Reset
+          this.io.sendI2CWriteRequest(this.opts.address, [this.COMMANDS.PCA9685_MODE1, 0x10] ); // Sleep
+          this.io.sendI2CWriteRequest(this.opts.address, [this.COMMANDS.PCA9685_PRESCALE, 0x3] ); // Set prescalar
+          this.io.sendI2CWriteRequest(this.opts.address, [this.COMMANDS.PCA9685_MODE1, 0x0] ); // Wake up
+          nanosleep(5); // Wait 5 nanoseconds for restart
+          this.io.sendI2CWriteRequest(this.opts.address, [this.COMMANDS.PCA9685_MODE1, 0xa1] ); // Auto-increment
+
+          // Reset all PWM values
+          for (var i=0; i<16; i++) {
+            this.setPWM(i, 0, 0);
+          }
+
+          Board.Drivers[this.opts.address] = {
+            initialized: true
+          };
+        }
+      }
+    }
+  }
+};
+
 var Devices = {
   NONDIRECTIONAL: {
     pins: {
@@ -15,21 +99,16 @@ var Devices = {
       }
     },
     dir: {
-      value: function() {
-        console.log("Non-directional motor type");
+      value: function(speed, dir) {
+        speed = speed || this.speed();
         return this;
       }
     },
-    brake: {
+    resume: {
       value: function() {
-        this.speed({speed: 0, saveState: false});
-        this.emit("brake", null, new Date());
-      }
-    },
-    release: {
-      value: function() {
-        this.resume();
-        this.emit("release", null, new Date());
+        var speed = this.speed();
+        this.speed({speed: speed});
+        return this;
       }
     }
   },
@@ -47,55 +126,16 @@ var Devices = {
       }
     },
     dir: {
-      value: function(motor, speed, dir) {
+      value: function(speed, dir) {
 
         speed = speed || this.speed();
 
         this.stop();
 
-        this.io.digitalWrite(this.pins.dir, dir.value);
-        this.direction = dir.value;
-        this.start(speed);
+        this.setPin( this.pins.dir, dir.value );
+        this.direction = dir;
 
         this.emit(dir.name, null, new Date());
-
-        return this;
-      }
-    },
-    brake: {
-      value: function(duration) {
-
-        if (typeof this.pins.brake === "undefined") {
-          this.stop();
-          return this;
-        }
-
-        this.io.digitalWrite(this.pins.brake, 1);
-        this.io.digitalWrite(this.pins.dir, 1);
-        this.speed({speed: 255, saveState: false});
-        this.emit("brake", null, new Date());
-
-        if (duration) {
-          var motor = this;
-          this.board.wait(duration, function() {
-            motor.stop();
-          });
-        }
-
-        return this;
-      }
-    },
-    release: {
-      value: function() {
-
-        if (this.pins.brake) {
-          this.io.digitalWrite(this.pins.brake, 0);
-          this.io.digitalWrite(this.pins.dir, this.direction);
-
-          this.resume();
-
-          this.emit("release", null, new Date());
-        }
 
         return this;
       }
@@ -116,17 +156,17 @@ var Devices = {
       }
     },
     dir: {
-      value: function(motor, speed, dir) {
+      value: function(speed, dir) {
 
-        speed = speed || this.speed();
+        if (typeof speed === "undefined") {
+          speed = this.speed();
+        }
 
         this.stop();
-        this.direction = dir.value;
+        this.direction = dir;
 
-        this.io.digitalWrite(this.pins.cdir, 1 ^ dir.value);
-        this.io.digitalWrite(this.pins.dir, dir.value);
-
-        this.start(speed);
+        this.setPin( this.pins.cdir, 1 ^ dir.value );
+        this.setPin( this.pins.dir, dir.value );
 
         this.emit(dir.name, null, new Date());
 
@@ -136,9 +176,10 @@ var Devices = {
     brake: {
       value: function(duration) {
 
-        this.speed({speed:255, saveState: false});
-        this.io.digitalWrite(this.pins.dir, 1);
-        this.io.digitalWrite(this.pins.cdir, 1);
+        this.speed({speed:0, saveSpeed: false});
+        this.setPin( this.pins.dir, 1, 127 );
+        this.setPin( this.pins.cdir, 1, 128, 127 );
+        this.speed({speed:255, saveSpeed: false, braking: true});
         this.emit("brake", null, new Date());
 
         if (duration) {
@@ -147,18 +188,6 @@ var Devices = {
             motor.stop();
           });
         }
-
-        return this;
-      }
-    },
-    release: {
-      value: function() {
-
-        this.resume();
-
-        this.io.digitalWrite(this.pins.dir, this.direction);
-        this.io.digitalWrite(this.pins.cdir, 1 ^ this.direction);
-        this.emit("release", null, new Date());
 
         return this;
       }
@@ -171,7 +200,7 @@ var Devices = {
  * Motor
  * @constructor
  *
- * @param {Object} opts Options: pin|pins{pwm, dir[, cdir]}, device, interface, current
+ * @param {Object} opts Options: pin|pins{pwm, dir[, cdir]}, device, controller, current
  * @param {Number} pin A single pin for basic
  * @param {Array} pins A two or three digit array of pins [pwm, dir]|[pwm, dir, cdir]
  *
@@ -204,6 +233,16 @@ var Devices = {
  *        pwm: 3,
  *        dir: 12
  *      }
+ *    });
+ *
+ *
+ * Initializing 3 pin, I2C PCA9685 Motor Controllers:
+ * i.e. The Adafruit Motor Shield V2
+ *
+ *    new five.Motor({
+ *      pins: [ 8, 9, 10 ],
+ *      controller: "PCA9685",
+ *      address: 0x60
  *    });
  *
  *
@@ -264,6 +303,8 @@ var Devices = {
 
 function Motor(opts) {
 
+  var device, controller;
+
   if (!(this instanceof Motor)) {
     return new Motor(opts);
   }
@@ -272,17 +313,6 @@ function Motor(opts) {
   Board.Device.call(
     this, this.opts = Board.Options(opts)
   );
-
-  /* Note: Interface overrides device
-   * To the user we present both "device" and "interface"
-   * params to map logically to real-world things.
-   * "Devices" are motors and "interfaces" are controllers.
-   * Here in the the library we are not concerned with
-   * this distinction.
-   */
-  if (this.opts.interface) {
-    this.opts.device = this.opts.interface;
-  }
 
   // Derive device based on pins passed
   if (typeof this.opts.device === "undefined") {
@@ -297,7 +327,7 @@ function Motor(opts) {
   }
 
   // Allow users to pass in custom device types
-  var device = typeof this.opts.device === "string" ?
+  device = typeof this.opts.device === "string" ?
     Devices[this.opts.device] : this.opts.device;
 
   this.threshold = typeof this.opts.threshold !== "undefined" ?
@@ -306,24 +336,27 @@ function Motor(opts) {
   this.invertPWM = typeof this.opts.invertPWM !== "undefined" ?
     this.opts.invertPWM : false;
 
-  // We need to store the state of the dir pin for release()
-  this.direction = 0;
-
   Object.defineProperties(this, device);
 
-  // Set the PWM pin to PWM mode
-  this.io.pinMode(this.pins.pwm, this.io.MODES.PWM);
+  /**
+   * Note: Controller decorates the device. Used for adding
+   * special controllers (i.e. PCA9685)
+   **/
+  if (this.opts.controller) {
+    controller = typeof this.opts.controller === "string" ?
+      Controllers[this.opts.controller] : this.opts.controller;
 
-  ["dir", "cdir", "brake"].forEach(function(pin) {
-    if (this.pins[pin]) {
-      this.io.pinMode(this.pins[pin], this.io.MODES.OUTPUT);
-    }
-  }, this);
+    Object.defineProperties(this, controller);
+  }
 
   // current just wraps a Sensor
   if (this.opts.current) {
     this.opts.current.board = this.board;
     this.current = new Sensor(this.opts.current);
+  }
+
+  if (this.initialize) {
+    this.initialize( opts );
   }
 
   Object.defineProperties(this, {
@@ -338,29 +371,58 @@ function Motor(opts) {
       get: function() {
         return priv.get(this).currentSpeed;
       }
+    },
+    braking: {
+      get: function() {
+        return priv.get(this).braking;
+      }
     }
   });
-
 
   // Create a "state" entry for privately
   // storing the state of the motor
   priv.set(this, {
     isOn: false,
     currentSpeed: typeof this.opts.speed !== "undefined" ?
-      this.opts.speed : 128
+      this.opts.speed : 128,
+    braking: false
   });
+
+  // We need to store and initialize the state of the dir pin(s)
+  this.direction = { value: 1 };
+  this.dir( 0, this.direction);
 
 }
 
 util.inherits(Motor, events.EventEmitter);
 
+Motor.prototype.initialize = function() {
+
+  this.io.pinMode(this.pins.pwm, this.io.MODES.PWM);
+
+  ["dir", "cdir", "brake"].forEach(function(pin) {
+    if (this.pins[pin]) {
+      this.io.pinMode(this.pins[pin], this.io.MODES.OUTPUT);
+    }
+  }, this);
+
+};
+
+Motor.prototype.setPin = function(pin, value) {
+  this.io.digitalWrite( pin, value );
+};
+
+Motor.prototype.setPWM = function(pin, value) {
+  this.io.analogWrite(pin, value);
+};
+
 Motor.prototype.speed = function(opts) {
 
-  if (typeof opts === 'undefined') {
+  if (typeof opts === "undefined") {
     return this.currentSpeed;
   } else {
 
-    if (typeof opts === 'number') {
+    if (typeof opts === "number") {
       opts = {
         speed: opts
       };
@@ -368,26 +430,31 @@ Motor.prototype.speed = function(opts) {
 
     opts.speed = Board.constrain(opts.speed, 0, 255);
 
-    opts.saveState = typeof opts.saveState !== "undefined" ?
-      opts.saveState : true;
+    opts.saveSpeed = typeof opts.saveSpeed !== "undefined" ?
+      opts.saveSpeed : true;
 
     if (opts.speed < this.threshold) {
       opts.speed = 0;
     }
 
-    if (opts.saveState) {
-      // Update stored values
-      priv.set(this, {
-        isOn: opts.speed === 0 ?
-          false : true,
-        currentSpeed: opts.speed
-      });
+    var state = priv.get(this);
+
+    state.isOn = opts.speed === 0 ? false : true;
+
+    if (opts.saveSpeed) {
+      state.currentSpeed = opts.speed;
     }
 
-    if (this.invertPWM && this.direction === 1) {
+    if (opts.braking) {
+      state.braking = true;
+    }
+
+    priv.set(this, state);
+
+    if (this.invertPWM && this.direction.value === 1) {
       opts.speed ^= 0xff;
     }
-    this.io.analogWrite(this.pins.pwm, opts.speed);
+    this.setPWM(this.pins.pwm, opts.speed);
 
     return this;
   }
@@ -398,16 +465,15 @@ Motor.prototype.speed = function(opts) {
 Motor.prototype.start = function(speed) {
   // Send a signal to turn on the motor and run at given speed in whatever
   // direction is currently set.
-
-  if (this.pins.brake) {
-    this.io.digitalWrite(this.pins.brake, 0);
+  if (this.pins.brake && this.braking) {
+    this.setPin( this.pins.brake, 0 );
   }
 
   // get current speed if nothing provided.
-  speed = typeof speed !== 'undefined' ?
+  speed = typeof speed !== "undefined" ?
     speed : this.speed();
 
-  this.speed(speed);
+  this.speed({ speed: speed, braking: false });
 
   // "start" event is fired when the motor is started
   if (speed > 0) {
@@ -418,21 +484,46 @@ Motor.prototype.start = function(speed) {
 };
 
 Motor.prototype.stop = function() {
-
-  this.speed(0);
-
-  this.release();
-
-  // "stop" event is fired when the motor is stopped
+  this.speed({ speed: 0, saveSpeed: false });
   this.emit("stop", null, new Date());
 
   return this;
 };
 
-Motor.prototype.resume = function() {
+Motor.prototype.brake = function(duration) {
+  if (typeof this.pins.brake === "undefined") {
+    if (this.board.io.name !== "Mock") {
+      console.log("Non-braking motor type");
+    }
+    this.stop();
+  } else {
+    this.setPin( this.pins.brake, 1 );
+    this.setPin( this.pins.dir, 1 );
+    this.speed({speed: 255, saveSpeed: false, braking: true});
+    this.emit("brake", null, new Date());
 
+    if (duration) {
+      var motor = this;
+      this.board.wait(duration, function() {
+        motor.resume();
+      });
+    }
+  }
+
+  return this;
+};
+
+Motor.prototype.release = function() {
+  this.resume();
+  this.emit("release", null, new Date());
+
+  return this;
+};
+
+Motor.prototype.resume = function() {
   var speed = this.speed();
-  this.speed(speed);
+  this.dir(speed, this.direction);
+  this.start(speed);
 
   return this;
 };
@@ -465,9 +556,9 @@ Motor.prototype.resume = function() {
     value: 0
   }
 ].forEach(function(dir) {
-
   var method = function(speed) {
-    this.dir(this, speed, dir);
+    this.dir(speed, dir);
+    this.start( speed );
     return this;
   };
 

--- a/programs.json
+++ b/programs.json
@@ -48,6 +48,7 @@
     "motor-brake.js",
     "motor-current.js",
     "motor-hbridge.js",
+    "motor-PCA9685.js",
     "motor-3-pin.js",
     "motobot.js",
 

--- a/test/animation.js
+++ b/test/animation.js
@@ -294,12 +294,13 @@ exports["Animation"] = {
       testContext.count++;
       if (testContext.count > 2) {
         testContext.animation.playLoop.stop();
-        test.ok(Math.abs(new Date() - startTime - 1500) < 5);
-        test.ok(testContext.servoWrite.callCount === 16);
+        test.ok(Math.abs(new Date() - startTime - 1500) < 10);
+        test.ok(Math.abs(testContext.servoWrite.callCount - 15) <= 1);
         test.done();
       }
     };
 
+    testContext.servoWrite.reset();
     this.animation.enqueue(tempSegment);
 
   },
@@ -617,21 +618,21 @@ exports["Animation"] = {
     tempSegment.cuePoints = [0, 0.3, 0.4, 0.5, 0.8, 1.0];
 
     tempSegment.oncomplete = function() {
-        test.ok(Math.abs(testContext.mockChain.result[0][0] - 56.66) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[0][1] - 6.66) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[0][2]) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[1][0] - 35) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[1][1] - 25) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[1][2] - 15) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[2][0] - 10) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[2][1] - 53.33) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[2][2] - 20) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[3][0] - 10) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[3][1] - 80) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[3][2] - 20) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[4][0] - 50) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[4][1] - 60) <= 0.1);
-        test.ok(Math.abs(testContext.mockChain.result[4][2] + 20) <= 0.1);
+        test.ok(Math.abs(testContext.mockChain.result[0][0] - 56.66) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[0][1] - 6.66) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[0][2]) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[1][0] - 35) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[1][1] - 25) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[1][2] - 15) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[2][0] - 10) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[2][1] - 53.33) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[2][2] - 20) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[3][0] - 10) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[3][1] - 80) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[3][2] - 20) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[4][0] - 50) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[4][1] - 60) <= 0.5);
+        test.ok(Math.abs(testContext.mockChain.result[4][2] + 20) <= 0.5);
         tempSegment.result = [];
         test.done();
     };

--- a/test/motor.js
+++ b/test/motor.js
@@ -33,6 +33,10 @@ exports["Motor: Non-Directional"] = {
       name: "speed"
     }, {
       name: "resume"
+    }, {
+      name: "setPin"
+    }, {
+      name: "setPWM"
     }];
 
     this.instance = [{
@@ -62,65 +66,58 @@ exports["Motor: Non-Directional"] = {
     test.expect(3);
 
     test.equal(this.motor.pins.pwm, 11);
-    test.equal(this.motor.opts.device, 'NONDIRECTIONAL');
+    test.equal(this.motor.opts.device, "NONDIRECTIONAL");
     test.equal(typeof this.motor.pins.dir, "undefined");
 
     test.done();
   },
 
-  start: function(test) {
-    test.expect(1);
+  startStop: function(test) {
+    test.expect(3);
 
     this.motor.start();
     test.ok(this.spy.calledWith(11, 128));
-
-    test.done();
-  },
-
-  stop: function(test) {
-    test.expect(1);
+    this.spy.reset();
 
     this.motor.stop();
     test.ok(this.spy.calledWith(11, 0));
+    this.spy.reset();
 
+    this.motor.start();
+    test.ok(this.spy.calledWith(11, 128));
     test.done();
   },
 
-  brake: function(test) {
-    test.expect(1);
-
-    this.motor.stop();
-    test.ok(this.spy.calledWith(11, 0));
-
-    test.done();
-  },
-
-  release: function(test) {
+  startBrakeRelease: function(test) {
     test.expect(3);
 
-    this.motor.start(200);
-    test.ok(this.spy.calledWith(11, 200));
+    this.motor.start();
+    test.ok(this.spy.calledWith(11, 128));
+    this.spy.reset();
+
     this.motor.brake();
     test.ok(this.spy.calledWith(11, 0));
-    this.motor.release();
-    test.ok(this.spy.calledWith(11, 200));
+    this.spy.reset();
 
+    this.motor.release();
+    test.ok(this.spy.calledWith(11, 128));
     test.done();
   },
 
   threshold: function(test) {
-    test.expect(3);
+    test.expect(2);
 
     this.motor.threshold = 30;
     this.motor.start(20);
     test.ok(this.spy.calledWith(11, 0));
-    this.motor.brake();
-    test.ok(this.spy.calledWith(11, 0));
-    this.motor.release();
-    test.ok(this.spy.calledWith(11, 0));
+    this.spy.reset();
+
+    this.motor.start(40);
+    test.ok(this.spy.calledWith(11, 40));
 
     test.done();
   }
+
 };
 
 exports["Motor: Directional"] = {
@@ -141,6 +138,10 @@ exports["Motor: Directional"] = {
       name: "stop"
     }, {
       name: "resume"
+    }, {
+      name: "setPin"
+    }, {
+      name: "setPWM"
     }];
 
     this.instance = [{
@@ -177,20 +178,19 @@ exports["Motor: Directional"] = {
     test.done();
   },
 
-  start: function(test) {
-    test.expect(1);
+  startStop: function(test) {
+    test.expect(3);
 
     this.motor.start();
     test.ok(this.analogSpy.calledWith(11, 128));
 
-    test.done();
-  },
-
-  stop: function(test) {
-    test.expect(1);
-
+    this.analogSpy.reset();
     this.motor.stop();
     test.ok(this.analogSpy.calledWith(11, 0));
+
+    this.analogSpy.reset();
+    this.motor.start();
+    test.ok(this.analogSpy.calledWith(11, 128));
 
     test.done();
   },
@@ -199,16 +199,6 @@ exports["Motor: Directional"] = {
     test.expect(2);
 
     this.motor.forward(128);
-    test.ok(this.analogSpy.calledWith(11, 128));
-    test.ok(this.digitalSpy.calledWith(12, 1));
-
-    test.done();
-  },
-
-  fwd: function(test) {
-    test.expect(2);
-
-    this.motor.fwd(128);
     test.ok(this.analogSpy.calledWith(11, 128));
     test.ok(this.digitalSpy.calledWith(12, 1));
 
@@ -225,54 +215,37 @@ exports["Motor: Directional"] = {
     test.done();
   },
 
-  rev: function(test) {
-    test.expect(2);
-
-    this.motor.rev(128);
-    test.ok(this.analogSpy.calledWith(11, 128));
-    test.ok(this.digitalSpy.calledWith(12, 0));
-
-    test.done();
-  },
   brake: function(test) {
-    test.expect(8);
+    test.expect(6);
 
     this.motor.rev(128);
-    this.motor.brake();
     test.ok(this.analogSpy.calledWith(11, 0));
     test.ok(this.digitalSpy.calledWith(12, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
+    this.motor.brake();
+    test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.release();
     test.ok(this.analogSpy.calledWith(11, 128));
-    test.ok(this.digitalSpy.calledWith(12, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.forward(180);
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.brake();
     test.ok(this.analogSpy.calledWith(11, 0));
-    test.ok(this.digitalSpy.calledWith(12, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.release();
     test.ok(this.analogSpy.calledWith(11, 180));
-    test.ok(this.digitalSpy.calledWith(12, 1));
 
-    test.done();
-  },
-
-  timedBrake: function(test) {
-    var clock = sinon.useFakeTimers();
-    test.expect(4);
-
-    this.motor.rev(128);
-
-    this.motor.brake(1000);
-    test.ok(this.analogSpy.calledWith(11, 0));
-    test.ok(this.digitalSpy.calledWith(12, 0));
-
-    clock.tick(1000);
-    test.ok(this.analogSpy.calledWith(11, 128));
-    test.ok(this.digitalSpy.calledWith(12, 0));
-
-    clock.restore();
     test.done();
   },
 
@@ -282,10 +255,18 @@ exports["Motor: Directional"] = {
     this.motor.threshold = 30;
     this.motor.start(20);
     test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.brake();
     test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.release();
     test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     test.done();
   }
@@ -309,6 +290,10 @@ exports["Motor: Directional with no speed passed"] = {
       name: "stop"
     }, {
       name: "resume"
+    }, {
+      name: "setPin"
+    }, {
+      name: "setPWM"
     }];
 
     this.instance = [{
@@ -323,6 +308,7 @@ exports["Motor: Directional with no speed passed"] = {
   },
 
   shape: function(test) {
+
     test.expect(this.proto.length + this.instance.length);
 
     this.proto.forEach(function(method) {
@@ -341,14 +327,29 @@ exports["Motor: Directional with no speed passed"] = {
 
     this.motor.forward();
     test.ok(this.analogSpy.calledWith(11, 128));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.stop();
     test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.forward(200);
     test.ok(this.analogSpy.calledWith(11, 200));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.stop();
     test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.start();
     test.ok(this.analogSpy.calledWith(11, 200));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.stop();
     test.ok(this.analogSpy.calledWith(11, 0));
 
@@ -361,8 +362,14 @@ exports["Motor: Directional with no speed passed"] = {
     this.motor.threshold = 30;
     this.motor.start(20);
     test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.brake();
     test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.release();
     test.ok(this.analogSpy.calledWith(11, 0));
 
@@ -404,6 +411,10 @@ exports["Motor: Directional with Brake"] = {
       name: "release"
     }, {
       name: "resume"
+    }, {
+      name: "setPin"
+    }, {
+      name: "setPWM"
     }];
 
     this.instance = [{
@@ -441,112 +452,100 @@ exports["Motor: Directional with Brake"] = {
     test.done();
   },
 
-  start: function(test) {
+  startStop: function(test) {
     test.expect(2);
 
     this.motor.start();
     test.ok(this.analogSpy.calledWith(3, 128));
-    test.ok(this.digitalSpy.calledWith(9, 0));
-
-    test.done();
-  },
-
-  stop: function(test) {
-    test.expect(2);
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.stop();
     test.ok(this.analogSpy.calledWith(3, 0));
-    test.ok(this.digitalSpy.calledWith(9, 0));
 
     test.done();
   },
 
   forward: function(test) {
-    test.expect(3);
+    test.expect(2);
 
     this.motor.forward(128);
     test.ok(this.analogSpy.calledWith(3, 128));
     test.ok(this.digitalSpy.calledWith(12, 1));
-    test.ok(this.digitalSpy.calledWith(9, 0));
-
-    test.done();
-  },
-
-  fwd: function(test) {
-    test.expect(3);
-
-    this.motor.fwd(128);
-    test.ok(this.analogSpy.calledWith(3, 128));
-    test.ok(this.digitalSpy.calledWith(12, 1));
-    test.ok(this.digitalSpy.calledWith(9, 0));
 
     test.done();
   },
 
   reverse: function(test) {
-    test.expect(3);
+    test.expect(2);
 
     this.motor.reverse(128);
     test.ok(this.analogSpy.calledWith(3, 128));
     test.ok(this.digitalSpy.calledWith(12, 0));
-    test.ok(this.digitalSpy.calledWith(9, 0));
-
-    test.done();
-  },
-
-  rev: function(test) {
-    test.expect(3);
-
-    this.motor.rev(128);
-    test.ok(this.analogSpy.calledWith(3, 128));
-    test.ok(this.digitalSpy.calledWith(12, 0));
-    test.ok(this.digitalSpy.calledWith(9, 0));
 
     test.done();
   },
 
   brake: function(test) {
-    test.expect(12);
+    test.expect(14);
 
     this.motor.rev(128);
+    test.ok(this.analogSpy.calledWith(3, 128));
+    test.ok(this.digitalSpy.calledWith(12, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.brake();
     test.ok(this.analogSpy.calledWith(3, 255));
     test.ok(this.digitalSpy.calledWith(12, 1));
     test.ok(this.digitalSpy.calledWith(9, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.release();
     test.ok(this.analogSpy.calledWith(3, 128));
     test.ok(this.digitalSpy.calledWith(12, 0));
     test.ok(this.digitalSpy.calledWith(9, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.forward(180);
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.brake();
     test.ok(this.analogSpy.calledWith(3, 255));
     test.ok(this.digitalSpy.calledWith(12, 1));
     test.ok(this.digitalSpy.calledWith(9, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.release();
     test.ok(this.analogSpy.calledWith(3, 180));
     test.ok(this.digitalSpy.calledWith(12, 1));
     test.ok(this.digitalSpy.calledWith(9, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     test.done();
   },
 
   timedBrake: function(test) {
     var clock = sinon.useFakeTimers();
-    test.expect(6);
+    test.expect(4);
 
     this.motor.rev(128);
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.brake(1000);
     test.ok(this.analogSpy.calledWith(3, 255));
-    test.ok(this.digitalSpy.calledWith(12, 1));
     test.ok(this.digitalSpy.calledWith(9, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     clock.tick(1000);
     test.ok(this.analogSpy.calledWith(3, 0));
-    test.ok(this.digitalSpy.calledWith(12, 1));
     test.ok(this.digitalSpy.calledWith(9, 0));
 
     clock.restore();
@@ -554,15 +553,27 @@ exports["Motor: Directional with Brake"] = {
   },
 
   threshold: function(test) {
-    test.expect(3);
+    test.expect(7);
 
     this.motor.threshold = 30;
     this.motor.start(20);
     test.ok(this.analogSpy.calledWith(3, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.brake();
-    test.ok(this.analogSpy.calledWith(3, 0));
+    test.ok(this.analogSpy.calledWith(3, 255));
+    test.ok(this.digitalSpy.calledWith(9, 1));
+    test.ok(this.digitalSpy.calledWith(12, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.release();
     test.ok(this.analogSpy.calledWith(3, 0));
+    test.ok(this.digitalSpy.calledWith(9, 0));
+    test.ok(this.digitalSpy.calledWith(12, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     test.done();
   }
@@ -606,6 +617,10 @@ exports["Motor: Directional with Current Sensing Pin"] = {
       name: "release"
     }, {
       name: "resume"
+    }, {
+      name: "setPin"
+    }, {
+      name: "setPWM"
     }];
 
     this.instance = [{
@@ -681,6 +696,10 @@ exports["Motor: Directional - Three Pin"] = {
       name: "rev"
     }, {
       name: "resume"
+    }, {
+      name: "setPin"
+    }, {
+      name: "setPWM"
     }];
 
     this.instance = [{
@@ -719,9 +738,11 @@ exports["Motor: Directional - Three Pin"] = {
   },
 
   start: function(test) {
-    test.expect(1);
+    test.expect(3);
 
     this.motor.start();
+    test.ok(this.digitalSpy.calledWith(13, 0));
+    test.ok(this.digitalSpy.calledWith(12, 1));
     test.ok(this.analogSpy.calledWith(11, 128));
 
     test.done();
@@ -747,17 +768,6 @@ exports["Motor: Directional - Three Pin"] = {
     test.done();
   },
 
-  fwd: function(test) {
-    test.expect(3);
-
-    this.motor.fwd(128);
-    test.ok(this.analogSpy.calledWith(11, 128));
-    test.ok(this.digitalSpy.calledWith(12, 1));
-    test.ok(this.digitalSpy.calledWith(13, 0));
-
-    test.done();
-  },
-
   reverse: function(test) {
     test.expect(3);
 
@@ -769,25 +779,19 @@ exports["Motor: Directional - Three Pin"] = {
     test.done();
   },
 
-  rev: function(test) {
-    test.expect(3);
-
-    this.motor.rev(128);
-    test.ok(this.analogSpy.calledWith(11, 128));
-    test.ok(this.digitalSpy.calledWith(12, 0));
-    test.ok(this.digitalSpy.calledWith(13, 1));
-
-    test.done();
-  },
-
   brakeRelease: function(test) {
     test.expect(6);
 
     this.motor.rev(128);
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.brake();
     test.ok(this.analogSpy.calledWith(11, 255));
     test.ok(this.digitalSpy.calledWith(12, 1));
     test.ok(this.digitalSpy.calledWith(13, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.release();
     test.ok(this.analogSpy.calledWith(11, 128));
@@ -826,6 +830,10 @@ exports["Motor: Inverse Speed When Forward"] = {
       name: "rev"
     }, {
       name: "resume"
+    }, {
+      name: "setPin"
+    }, {
+      name: "setPWM"
     }];
 
     this.instance = [{
@@ -872,13 +880,19 @@ exports["Motor: Inverse Speed When Forward"] = {
     this.motor.forward(255);
     test.ok(this.analogSpy.calledWith(11, 0));
     test.ok(this.digitalSpy.calledWith(12, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.forward(180);
     test.ok(this.analogSpy.calledWith(11, 75));
     test.ok(this.digitalSpy.calledWith(12, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.stop();
     test.ok(this.analogSpy.calledWith(11, 255));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.start();
     test.ok(this.analogSpy.calledWith(11, 75));
@@ -892,13 +906,19 @@ exports["Motor: Inverse Speed When Forward"] = {
     this.motor.reverse(255);
     test.ok(this.analogSpy.calledWith(11, 255));
     test.ok(this.digitalSpy.calledWith(12, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.reverse(180);
     test.ok(this.analogSpy.calledWith(11, 180));
     test.ok(this.digitalSpy.calledWith(12, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.stop();
     test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.start();
     test.ok(this.analogSpy.calledWith(11, 180));
@@ -913,36 +933,53 @@ exports["Motor: Inverse Speed When Forward"] = {
     // pwm values are inversed when the enable pin is high
     test.ok(this.analogSpy.calledWith(11, 0));
     test.ok(this.digitalSpy.calledWith(12, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.brake();
     test.ok(this.analogSpy.calledWith(11, 255));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.release();
     test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.reverse(255);
     test.ok(this.analogSpy.calledWith(11, 255));
     test.ok(this.digitalSpy.calledWith(12, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.brake();
-    test.ok(this.analogSpy.calledWith(11, 255));
+    test.ok(this.analogSpy.calledWith(11, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.release();
-    test.ok(this.analogSpy.calledWith(11, 0));
+    test.ok(this.analogSpy.calledWith(11, 255));
 
     test.done();
   },
 
   threshold: function(test) {
-    test.expect(3);
+    test.expect(4);
 
     this.motor.threshold = 30;
     this.motor.start(20);
-    test.ok(this.analogSpy.calledWith(11, 0));
+    test.ok(this.analogSpy.calledWith(11, 255));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.brake();
-    test.ok(this.analogSpy.calledWith(11, 0));
+    test.ok(this.analogSpy.calledWith(11, 255));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
+
     this.motor.release();
-    test.ok(this.analogSpy.calledWith(11, 0));
+    test.ok(this.analogSpy.calledWith(11, 255));
+    test.ok(this.digitalSpy.calledWith(12, 1));
 
     test.done();
   }
@@ -980,6 +1017,10 @@ exports["Motor: Inverse Speed With Brake"] = {
       name: "rev"
     }, {
       name: "resume"
+    }, {
+      name: "setPin"
+    }, {
+      name: "setPWM"
     }];
 
     this.instance = [{
@@ -1015,22 +1056,32 @@ exports["Motor: Inverse Speed With Brake"] = {
     this.motor.forward(255);
     test.ok(this.analogSpy.calledWith(11, 0));
     test.ok(this.digitalSpy.calledWith(12, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.brake();
     test.ok(this.analogSpy.calledWith(11, 0));
     test.ok(this.digitalSpy.calledWith(9, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.release();
     test.ok(this.analogSpy.calledWith(11, 0));
     test.ok(this.digitalSpy.calledWith(9, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.reverse(255);
     test.ok(this.analogSpy.calledWith(11, 255));
     test.ok(this.digitalSpy.calledWith(12, 0));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.brake();
     test.ok(this.analogSpy.calledWith(11, 255));
     test.ok(this.digitalSpy.calledWith(9, 1));
+    this.analogSpy.reset();
+    this.digitalSpy.reset();
 
     this.motor.release();
     test.ok(this.analogSpy.calledWith(11, 0));
@@ -1038,5 +1089,240 @@ exports["Motor: Inverse Speed With Brake"] = {
 
     test.done();
   }
+
+};
+
+exports["Motor: I2C - PCA9685"] = {
+  setUp: function(done) {
+    this.board = newBoard();
+    this.writeSpy = sinon.spy(this.board.io, "sendI2CWriteRequest");
+    this.readSpy = sinon.spy(this.board.io, "sendI2CReadRequest");
+    this.motor = new Motor({
+      board: this.board,
+      pins: [8, 9, 10],
+      controller: "PCA9685",
+      address: 0x60
+    });
+
+    this.proto = [{
+      name: "dir"
+    }, {
+      name: "start"
+    }, {
+      name: "stop"
+    }, {
+      name: "forward"
+    }, {
+      name: "fwd"
+    }, {
+      name: "reverse"
+    }, {
+      name: "rev"
+    }, {
+      name: "resume"
+    }, {
+      name: "setPin"
+    }, {
+      name: "setPWM"
+    }];
+
+    this.instance = [{
+      name: "pins"
+    }, {
+      name: "threshold"
+    }, {
+      name: "speed"
+    }];
+
+    done();
+  },
+
+  shape: function(test) {
+    test.expect(this.proto.length + this.instance.length);
+
+    this.proto.forEach(function(method) {
+      test.equal(typeof this.motor[method.name], "function");
+    }, this);
+
+    this.instance.forEach(function(property) {
+      test.notEqual(typeof this.motor[property.name], "undefined");
+    }, this);
+
+    test.done();
+  },
+
+  pinList: function(test) {
+    test.expect(3);
+
+    test.equal(this.motor.pins.pwm, 8);
+    test.equal(this.motor.pins.dir, 9);
+    test.equal(this.motor.pins.cdir, 10);
+
+    test.done();
+  },
+
+  start: function(test) {
+    test.expect(6);
+
+    this.motor.start();
+
+    test.equal(this.writeSpy.args[0][0], 0x60);
+    test.equal(this.writeSpy.args[3][1][0], 38);
+    test.equal(this.writeSpy.args[3][1][1], 0);
+    test.equal(this.writeSpy.args[3][1][2], 0);
+    test.equal(this.writeSpy.args[3][1][3], 2048);
+    test.equal(this.writeSpy.args[3][1][4], 8);
+
+    test.done();
+  },
+
+  stop: function(test) {
+    test.expect(6);
+
+    this.motor.stop();
+
+    test.equal(this.writeSpy.args[0][0], 0x60);
+    test.equal(this.writeSpy.args[0][1][0], 38);
+    test.equal(this.writeSpy.args[0][1][1], 0);
+    test.equal(this.writeSpy.args[0][1][2], 0);
+    test.equal(this.writeSpy.args[0][1][3], 0);
+    test.equal(this.writeSpy.args[0][1][4], 0);
+
+    test.done();
+  },
+
+  forward: function(test) {
+    test.expect(21);
+
+    this.motor.forward(128);
+
+    test.equal(this.writeSpy.args[0][0], 0x60);
+
+    test.equal(this.writeSpy.args[0][1][0], 38);
+    test.equal(this.writeSpy.args[0][1][1], 0);
+    test.equal(this.writeSpy.args[0][1][2], 0);
+    test.equal(this.writeSpy.args[0][1][3], 0);
+    test.equal(this.writeSpy.args[0][1][4], 0);
+
+    test.equal(this.writeSpy.args[1][1][0], 46);
+    test.equal(this.writeSpy.args[1][1][1], 0);
+    test.equal(this.writeSpy.args[1][1][2], 0);
+    test.equal(this.writeSpy.args[1][1][3], 0);
+    test.equal(this.writeSpy.args[1][1][4], 0);
+
+    test.equal(this.writeSpy.args[2][1][0], 42);
+    test.equal(this.writeSpy.args[2][1][1], 0);
+    test.equal(this.writeSpy.args[2][1][2], 0);
+    test.equal(this.writeSpy.args[2][1][3], 4080);
+    test.equal(this.writeSpy.args[2][1][4], 15);
+
+    test.equal(this.writeSpy.args[3][1][0], 38);
+    test.equal(this.writeSpy.args[3][1][1], 0);
+    test.equal(this.writeSpy.args[3][1][2], 0);
+    test.equal(this.writeSpy.args[3][1][3], 0);
+    test.equal(this.writeSpy.args[3][1][4], 0);
+    test.done();
+  },
+
+  reverse: function(test) {
+    test.expect(21);
+
+    this.motor.reverse(128);
+    test.equal(this.writeSpy.args[0][0], 0x60);
+
+    test.equal(this.writeSpy.args[0][1][0], 38);
+    test.equal(this.writeSpy.args[0][1][1], 0);
+    test.equal(this.writeSpy.args[0][1][2], 0);
+    test.equal(this.writeSpy.args[0][1][3], 0);
+    test.equal(this.writeSpy.args[0][1][4], 0);
+
+    test.equal(this.writeSpy.args[1][1][0], 46);
+    test.equal(this.writeSpy.args[1][1][1], 0);
+    test.equal(this.writeSpy.args[1][1][2], 0);
+    test.equal(this.writeSpy.args[1][1][3], 0);
+    test.equal(this.writeSpy.args[1][1][4], 0);
+
+    test.equal(this.writeSpy.args[2][1][0], 42);
+    test.equal(this.writeSpy.args[2][1][1], 0);
+    test.equal(this.writeSpy.args[2][1][2], 0);
+    test.equal(this.writeSpy.args[2][1][3], 4080);
+    test.equal(this.writeSpy.args[2][1][4], 15);
+
+    test.equal(this.writeSpy.args[3][1][0], 38);
+    test.equal(this.writeSpy.args[3][1][1], 0);
+    test.equal(this.writeSpy.args[3][1][2], 0);
+    test.equal(this.writeSpy.args[3][1][3], 0);
+    test.equal(this.writeSpy.args[3][1][4], 0);
+
+    test.done();
+  },
+
+  brakeRelease: function(test) {
+    test.expect(42);
+
+    this.motor.rev(128);
+    this.writeSpy.reset();
+
+    this.motor.brake();
+    test.equal(this.writeSpy.args[0][0], 0x60);
+
+    test.equal(this.writeSpy.args[0][1][0], 38);
+    test.equal(this.writeSpy.args[0][1][1], 0);
+    test.equal(this.writeSpy.args[0][1][2], 0);
+    test.equal(this.writeSpy.args[0][1][3], 0);
+    test.equal(this.writeSpy.args[0][1][4], 0);
+
+    test.equal(this.writeSpy.args[1][1][0], 42);
+    test.equal(this.writeSpy.args[1][1][1], 0);
+    test.equal(this.writeSpy.args[1][1][2], 0);
+    test.equal(this.writeSpy.args[1][1][3], 2032);
+    test.equal(this.writeSpy.args[1][1][4], 7);
+
+    test.equal(this.writeSpy.args[2][1][0], 46);
+    test.equal(this.writeSpy.args[2][1][1], 2032);
+    test.equal(this.writeSpy.args[2][1][2], 7);
+    test.equal(this.writeSpy.args[2][1][3], 4080);
+    test.equal(this.writeSpy.args[2][1][4], 15);
+
+    test.equal(this.writeSpy.args[3][1][0], 38);
+    test.equal(this.writeSpy.args[3][1][1], 0);
+    test.equal(this.writeSpy.args[3][1][2], 0);
+    test.equal(this.writeSpy.args[3][1][3], 4080);
+    test.equal(this.writeSpy.args[3][1][4], 15);
+
+    this.writeSpy.reset();
+
+    this.motor.release();
+
+    test.equal(this.writeSpy.args[0][0], 0x60);
+
+    test.equal(this.writeSpy.args[0][1][0], 38);
+    test.equal(this.writeSpy.args[0][1][1], 0);
+    test.equal(this.writeSpy.args[0][1][2], 0);
+    test.equal(this.writeSpy.args[0][1][3], 0);
+    test.equal(this.writeSpy.args[0][1][4], 0);
+
+    test.equal(this.writeSpy.args[1][1][0], 46);
+    test.equal(this.writeSpy.args[1][1][1], 0);
+    test.equal(this.writeSpy.args[1][1][2], 0);
+    test.equal(this.writeSpy.args[1][1][3], 4080);
+    test.equal(this.writeSpy.args[1][1][4], 15);
+
+    test.equal(this.writeSpy.args[2][1][0], 42);
+    test.equal(this.writeSpy.args[2][1][1], 0);
+    test.equal(this.writeSpy.args[2][1][2], 0);
+    test.equal(this.writeSpy.args[2][1][3], 0);
+    test.equal(this.writeSpy.args[2][1][4], 0);
+
+    test.equal(this.writeSpy.args[3][1][0], 38);
+    test.equal(this.writeSpy.args[3][1][1], 0);
+    test.equal(this.writeSpy.args[3][1][2], 0);
+    test.equal(this.writeSpy.args[3][1][3], 2048);
+    test.equal(this.writeSpy.args[3][1][4], 8);
+
+    this.writeSpy.reset();
+
+    test.done();
+  },
 
 };


### PR DESCRIPTION
The Adafruit V2 uses the NXP's PCA9685 I2C, Quad H-Bridge controller. There are other devices which use this controller so I targeted that rather than a single specific shield.

A couple of highlights.
- Braking works (that's not supported in the Adafruit library for some reason)
- You can stack 32 of these things :exclamation: 

In addition to Adafruit support, this PR addresses:
- Tests that were not checking to make sure that pins were being set in the right order #433
- Fixes the unrelated start(), stop(), start() issue brought up by @meshy in the #433 discussion thread
- Broke out resume, setPin and setPWM to wrapper functions for simplicity

I've also got the [updated wiki page](https://github.com/dtex/johnny-five/wiki/Motor) ready

I still would like to run another round of hardware testing, but I think it's ready for a look-see and nits.
