### PR TITLE
RGB.on() and .off() saves color state

### DIFF
--- a/lib/led.js
+++ b/lib/led.js
@@ -609,16 +609,17 @@ Led.RGB.prototype.on = function() {
   var state = priv.get(this);
 
   Led.RGB.colors.forEach(function(color) {
-    this[color].on();
-    this[color].brightness(
-      state[color] !== 0 ? state[color] : 255
-    );
+    this[color].brightness(255);
+    state[color] = this[color].value;
   }, this);
 };
 
 Led.RGB.prototype.off = function() {
+  var state = priv.get(this);
+  
   Led.RGB.colors.forEach(function(color) {
     this[color].off();
+    state[color] = this[color].value;
   }, this);
 };
 

--- a/test/led.js
+++ b/test/led.js
@@ -492,6 +492,8 @@ exports["Led.RGB"] = {
     }, {
       name: "off"
     }, {
+      name: "color"
+    }, {
       name: "toggle"
     }, {
       name: "brightness"
@@ -582,19 +584,41 @@ exports["Led.RGB"] = {
     test.done();
   },
   on: function(test) {
-    test.expect(1);
+    var redPin = 9,
+      greenPin = 10,
+      bluePin = 11;
+
+    test.expect(6);
 
     this.ledRgb.on();
-    test.ok(this.analog.calledWith(11, 255));
+    test.ok(this.analog.calledWith(redPin, 255));
+    test.ok(this.analog.calledWith(greenPin, 255));
+    test.ok(this.analog.calledWith(bluePin, 255));
+
+    var color = this.ledRgb.color();
+    test.equal(color.red, 255);
+    test.equal(color.green, 255);
+    test.equal(color.blue, 255);
 
     test.done();
   },
 
   off: function(test) {
-    test.expect(1);
+    var redPin = 9,
+      greenPin = 10,
+      bluePin = 11;
+
+    test.expect(6);
 
     this.ledRgb.off();
-    test.ok(this.analog.calledWith(11, 0));
+    test.ok(this.analog.calledWith(redPin, 0));
+    test.ok(this.analog.calledWith(greenPin, 0));
+    test.ok(this.analog.calledWith(bluePin, 0));
+
+    var color = this.ledRgb.color();
+    test.equal(color.red, 0);
+    test.equal(color.green, 0);
+    test.equal(color.blue, 0);
 
     test.done();
   },
@@ -637,6 +661,8 @@ exports["Led.RGB - Common Anode"] = {
       name: "on"
     }, {
       name: "off"
+    }, {
+      name: "color"
     }, {
       name: "toggle"
     }, {
@@ -708,19 +734,41 @@ exports["Led.RGB - Common Anode"] = {
   },
 
   on: function(test) {
-    test.expect(1);
+    var redPin = 9,
+      greenPin = 10,
+      bluePin = 11;
+
+    test.expect(6);
 
     this.ledRgb.on();
-    test.ok(this.spy.calledWith(11, 0));
+    test.ok(this.spy.calledWith(redPin, 0));
+    test.ok(this.spy.calledWith(greenPin, 0));
+    test.ok(this.spy.calledWith(bluePin, 0));
+
+    var color = this.ledRgb.color();
+    test.equal(color.red, 255);
+    test.equal(color.green, 255);
+    test.equal(color.blue, 255);
 
     test.done();
   },
 
   off: function(test) {
-    test.expect(1);
+    var redPin = 9,
+      greenPin = 10,
+      bluePin = 11;
+
+    test.expect(6);
 
     this.ledRgb.off();
-    test.ok(this.spy.calledWith(11, 255));
+    test.ok(this.spy.calledWith(redPin, 255));
+    test.ok(this.spy.calledWith(greenPin, 255));
+    test.ok(this.spy.calledWith(bluePin, 255));
+
+    var color = this.ledRgb.color();
+    test.equal(color.red, 0);
+    test.equal(color.green, 0);
+    test.equal(color.blue, 0);
 
     test.done();
   },


### PR DESCRIPTION
Led.RGB.on() and Led.RGB.off() weren’t saving color state.

It was also treating the RGB as individual LEDs and calling Led.on()
was causing unexpected results because there isn’t the concept of
individual brightness on the RGB pins. (It just produced unexpected
color combinations rather than “dimming” them.)

This simplified implementation will need to be revisited when/if #375
is addressed, but at least it’s consistent and intuitive for now.
Led.RGB.on() is essentially the same as Led.RGB.color(“#ffffff”) with
this update.

Color also wasn’t being checked for in the shape tests for RGB (both
varieties)

Fixes #445
