### PR TITLE
Changed the link to Raspi-IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ IO Plugins allow Johnny-Five code to communicate with any non-Arduino based hard
 - Pinoccio
   - [Pinoccio-IO](https://github.com/soldair/pinoccio-io/)
 - Raspberry Pi
-  - [Raspi-IO](https://gitlab.theoreticalideations.com/nebrius/raspi-io/)
+  - [Raspi-IO](https://github.com/bryan-m-hughes/raspi-io/)
 - Spark Core
   - [Spark-IO](https://github.com/rwaldron/spark-io/)
 - LightBlue Bean

--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -29,7 +29,7 @@ IO Plugins allow Johnny-Five code to communicate with any non-Arduino based hard
 - Pinoccio
   - [Pinoccio-IO](https://github.com/soldair/pinoccio-io/)
 - Raspberry Pi
-  - [Raspi-IO](https://gitlab.theoreticalideations.com/nebrius/raspi-io/)
+  - [Raspi-IO](https://github.com/bryan-m-hughes/raspi-io/)
 - Spark Core
   - [Spark-IO](https://github.com/rwaldron/spark-io/)
 - LightBlue Bean


### PR DESCRIPTION
I moved the Raspi-IO repo to GitHub, so updating the README here. FYI The old repo will remain live for at least another week.
