### PR TITLE
added comment for Motor.start to mention optional speed argument

### DIFF
--- a/docs/motor.md
+++ b/docs/motor.md
@@ -44,7 +44,8 @@ board.on("ready", function() {
 
   // Motor API
 
-  // start()
+  // start([speed])
+  // Optional argument of speed 0-225 if using a Pin that supports PWM.
   // Start the motor. `isOn` property set to |true|
   motor.start();
 


### PR DESCRIPTION
Was looking for the ability to control the speed of a simple DC motor connected through a transistor on a PWM pin. Apparently Motor.start() does take in an argument of `speed`. This should be added to the documentation.
