### PR TITLE
added comment mentioning optional speed parameter in Motor.start

### DIFF
--- a/docs/led.md
+++ b/docs/led.md
@@ -11,8 +11,6 @@ var five = require("johnny-five"),
   board = new five.Board();
 
 board.on("ready", function() {
-
-  console.log(this);
   // Default to pin 13
   var led = new five.Led(process.argv[2] || 13);
 

--- a/docs/motor.md
+++ b/docs/motor.md
@@ -44,8 +44,11 @@ board.on("ready", function() {
 
   // Motor API
 
-  // start()
+  // start([speed)
   // Start the motor. `isOn` property set to |true|
+  // Takes an optional parameter `speed` [0-255]
+  // to define the motor speed if a PWM Pin is
+  // used to connect the motor.
   motor.start();
 
   // stop()

--- a/eg/motor.js
+++ b/eg/motor.js
@@ -35,8 +35,11 @@ board.on("ready", function() {
 
   // Motor API
 
-  // start()
+  // start([speed)
   // Start the motor. `isOn` property set to |true|
+  // Takes an optional parameter `speed` [0-255]
+  // to define the motor speed if a PWM Pin is
+  // used to connect the motor.
   motor.start();
 
   // stop()


### PR DESCRIPTION
Added a comment to Motor.start API mentioning it accepts an optional speed parameter [0-255] if the motor is controlled using a PWM pin.
