### PR TITLE
[RFR] Sensors should return some float values

### DIFF
--- a/lib/sensor.js
+++ b/lib/sensor.js
@@ -222,9 +222,8 @@ function Sensor(opts) {
             return scale[value];
           }
 
-          mapped = Board.map(value, this.range[0], this.range[1], scale[0], scale[1]);
+          mapped = Board.fmap(value, this.range[0], this.range[1], scale[0], scale[1]);
           constrain = Board.constrain(mapped, scale[0], scale[1]);
-
 
           return constrain;
         }

--- a/test/sensor.js
+++ b/test/sensor.js
@@ -116,7 +116,7 @@ exports["Sensor - Analog"] = {
   scale: function(test) {
     var callback = this.analogRead.args[0][1];
 
-    test.expect(2);
+    test.expect(3);
 
     // Scale the expected 0-1023 to a value between 50-100 (~75)
     this.sensor.scale(50, 100);
@@ -131,6 +131,14 @@ exports["Sensor - Analog"] = {
       test.equal(this.value, 50);
     });
     callback(0);
+    this.clock.tick(25);
+
+    // Ensure sensors may return float values
+    this.sensor.scale([0, 102.3]);
+    this.sensor.once("change", function() {
+      test.equal(this.value, 1.2);
+    });
+    callback(12);
     this.clock.tick(25);
 
     test.done();


### PR DESCRIPTION
Fixes https://github.com/rwaldron/johnny-five/issues/492.

Now sensors return also float values.

Question for the reviewer: what is the purpose of `analog` property in [sensor.js](https://github.com/rwaldron/johnny-five/blob/master/lib/sensor.js#L186)? Shouldn't the scale be also applied?
