### PR TITLE
Adding support for Adafruit Servo Shield and deadband

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ board.on("ready", function() {
 - [Servo Diagnostic](https://github.com/rwldrn/johnny-five/blob/master/docs/servo-diagnostic.md)
 - [Servo Array](https://github.com/rwldrn/johnny-five/blob/master/docs/servo-array.md)
 - [Boe Test Servos](https://github.com/rwldrn/johnny-five/blob/master/docs/boe-test-servos.md)
+- [Servo PCA9685](https://github.com/rwldrn/johnny-five/blob/master/docs/servo-PCA9685.md)
 
 ### Motor
 - [Motor](https://github.com/rwldrn/johnny-five/blob/master/docs/motor.md)

--- a/docs/servo-PCA9685.md
+++ b/docs/servo-PCA9685.md
@@ -1,0 +1,102 @@
+# Servo PCA9685
+
+Run with:
+```bash
+node eg/servo-PCA9685.js
+```
+
+
+```javascript
+var five = require("johnny-five");
+
+five.Board().on("ready", function() {
+  console.log("Connected");
+
+  // Initialize the servo
+  var servo = new five.Servo({
+    address: 0x40,
+    pin: 0,
+    controller: "PCA9685"
+  });
+
+  // The address of the shield.
+  //    Defaults to 0x40
+  // controller: The type of Servo/PWM controller being used.
+  //   Defaults to "standard".
+
+  // Add servo to REPL (optional)
+  this.repl.inject({
+    servo: servo
+  });
+
+
+  // Servo API
+
+  // min()
+  //
+  // set the servo to the minimum degrees
+  // defaults to 0
+  //
+  // eg. servo.min();
+
+  // max()
+  //
+  // set the servo to the maximum degrees
+  // defaults to 180
+  //
+  // eg. servo.max();
+
+  // center()
+  //
+  // centers the servo to 90°
+  //
+  // servo.center();
+
+  // to( deg[, duration] )
+  //
+  // Moves the servo to position by degrees
+  // duration (optional) sets duration of movement.
+  //
+  // servo.to( 90 );
+
+  // step( deg )
+  //
+  // Moves the servo step degrees relative to current position
+  //
+  // servo.step( -10 );
+
+  // sweep( obj )
+  //
+  // Perform a min-max cycling servo sweep (defaults to 0-180)
+  // optionally accepts an object of sweep settings:
+  // {
+  //    lapse: time in milliseconds to wait between moves
+  //           defaults to 500ms
+  //    degrees: distance in degrees to move
+  //           defaults to 10°
+  // }
+  //
+  //servo.sweep();
+
+});
+
+
+// References
+//
+// http://servocity.com/html/hs-7980th_servo.html
+
+```
+
+
+
+
+
+
+
+
+
+## License
+Copyright (c) 2012-2013 Rick Waldron <waldron.rick@gmail.com>
+Licensed under the MIT license.
+Copyright (c) 2014 The Johnny-Five Contributors
+Licensed under the MIT license.

--- a/eg/servo-PCA9685.js
+++ b/eg/servo-PCA9685.js
@@ -1,0 +1,77 @@
+var five = require("../lib/johnny-five.js");
+
+five.Board().on("ready", function() {
+  console.log("Connected");
+
+  // Initialize the servo
+  var servo = new five.Servo({
+    address: 0x40,
+    pin: 0,
+    controller: "PCA9685"
+  });
+
+  // The address of the shield.
+  //    Defaults to 0x40
+  // controller: The type of Servo/PWM controller being used.
+  //   Defaults to "standard".
+
+  // Add servo to REPL (optional)
+  this.repl.inject({
+    servo: servo
+  });
+
+
+  // Servo API
+
+  // min()
+  //
+  // set the servo to the minimum degrees
+  // defaults to 0
+  //
+  // eg. servo.min();
+
+  // max()
+  //
+  // set the servo to the maximum degrees
+  // defaults to 180
+  //
+  // eg. servo.max();
+
+  // center()
+  //
+  // centers the servo to 90°
+  //
+  // servo.center();
+
+  // to( deg[, duration] )
+  //
+  // Moves the servo to position by degrees
+  // duration (optional) sets duration of movement.
+  //
+  // servo.to( 90 );
+
+  // step( deg )
+  //
+  // Moves the servo step degrees relative to current position
+  //
+  // servo.step( -10 );
+
+  // sweep( obj )
+  //
+  // Perform a min-max cycling servo sweep (defaults to 0-180)
+  // optionally accepts an object of sweep settings:
+  // {
+  //    lapse: time in milliseconds to wait between moves
+  //           defaults to 500ms
+  //    degrees: distance in degrees to move
+  //           defaults to 10°
+  // }
+  //
+  //servo.sweep();
+
+});
+
+
+// References
+//
+// http://servocity.com/html/hs-7980th_servo.html

--- a/lib/board.js
+++ b/lib/board.js
@@ -228,6 +228,9 @@ function Board(opts) {
   // Registry of devices by pin address
   this.register = [];
 
+  // Registry of drivers by address (i.e. I2C Controllers)
+  this.Drivers = {};
+
   // Identify for connect hardware cache
   if (!this.id) {
     this.id = __.uid();

--- a/lib/motor.js
+++ b/lib/motor.js
@@ -2,15 +2,11 @@ var Board = require("../lib/board.js"),
   events = require("events"),
   util = require("util"),
   Sensor = require("../lib/sensor.js"),
-  ShiftRegister = require("../lib/shiftregister.js");
+  ShiftRegister = require("../lib/shiftregister.js"),
+  nanosleep = require("../lib/sleep.js").nano;
 
 var priv = new Map(),
     registers = new Map();
-
-function nanosleep(ns) {
-  var start = process.hrtime();
-  while (process.hrtime() < start + ns) {}
-}
 
 function registerKey(registerOpts) {
   return Object.keys(registerOpts).sort().reduce(function(accum, key) {
@@ -19,7 +15,7 @@ function registerKey(registerOpts) {
   }, "");
 }
 
-function latch(state, bit, on) { 
+function latch(state, bit, on) {
   return on ? state |= (1 << bit) : state &= ~(1 << bit);
 }
 
@@ -129,13 +125,9 @@ var Controllers = {
     initialize: {
       value: function(opts) {
 
-        if (!Board.Drivers) {
-          Board.Drivers = {};
-        }
-
-        if (!Board.Drivers[this.opts.address]) {
+        if (!this.board.Drivers[this.opts.address]) {
           this.io.sendI2CConfig();
-          Board.Drivers[this.opts.address] = {
+          this.board.Drivers[this.opts.address] = {
             initialized: false
           };
 
@@ -157,7 +149,7 @@ var Controllers = {
             this.setPWM(i, 0, 0);
           }
 
-          Board.Drivers[this.opts.address].initialized = true;
+          this.board.Drivers[this.opts.address].initialized = true;
         }
       }
     }

--- a/lib/servo.js
+++ b/lib/servo.js
@@ -4,11 +4,108 @@ var events = require("events");
 var Emitter = require("events").EventEmitter;
 var util = require("util");
 var __ = require("../lib/fn.js");
+var nanosleep = require("../lib/sleep.js").nano;
 var Animation = require("../lib/animation.js");
 
-// Sensor instance private data
+// Servo instance private data
 var priv = new Map();
 var SERVOS = [];
+
+var Controllers = {
+  PCA9685: {
+    COMMANDS: {
+      value: {
+        PCA9685_MODE1: 0x0,
+        PCA9685_PRESCALE: 0xFE,
+        LED0_ON_L: 0x6
+      }
+    },
+    servoWrite: {
+      value: function(pin, degrees) {
+
+        var on, off;
+        // If same degrees, emit "move:complete" and return immediately.
+        if (this.last && this.last.degrees === degrees) {
+          //process.nextTick(this.emit.bind(this, "move:complete"));
+          this.emit("move:complete");
+          return this;
+        }
+
+        on = 0;
+        off = __.map(degrees, 0, 180, this.pwmRange[0]/4, this.pwmRange[1]/4 );
+
+        this.io.sendI2CWriteRequest(this.address, [this.COMMANDS.LED0_ON_L + 4 * (pin), on, on >> 8, off, off >> 8]);
+
+      }
+    },
+    initialize: {
+      value: function(opts) {
+        this.address = opts.address || 0x40;
+        this.pwmRange = opts.pwmRange || [544, 2400];
+
+        if (!this.board.Drivers[opts.address]) {
+          this.io.sendI2CConfig();
+          this.board.Drivers[opts.address] = {
+            initialized: false
+          };
+
+          // Reset
+          this.io.sendI2CWriteRequest(this.address, [this.COMMANDS.PCA9685_MODE1, 0x0]);
+          // Sleep
+          this.io.sendI2CWriteRequest(this.address, [this.COMMANDS.PCA9685_MODE1, 0x10]);
+          // Set prescalar
+          this.io.sendI2CWriteRequest(this.address, [this.COMMANDS.PCA9685_PRESCALE, 0x70]);
+          // Wake up
+          this.io.sendI2CWriteRequest(this.address, [this.COMMANDS.PCA9685_MODE1, 0x0]);
+          // Wait 5 nanoseconds for restart
+          nanosleep(5);
+          // Auto-increment
+          this.io.sendI2CWriteRequest(this.address, [this.COMMANDS.PCA9685_MODE1, 0xa1]);
+
+          this.board.Drivers[this.address].initialized = true;
+        }
+
+      }
+    }
+  },
+  Standard: {
+    initialize: {
+      value: function(opts, pinValue) {
+
+        // When in debug mode, if pin is not a PWM pin, emit an error
+        if (opts.debug && !this.board.pins.isServo(this.pin)) {
+          Board.Pins.Error({
+            pin: this.pin,
+            type: "PWM",
+            via: "Servo",
+          });
+        }
+
+        if (Array.isArray(opts.pwmRange)) {
+          this.io.servoConfig(this.pin, opts.pwmRange[0], opts.pwmRange[1]);
+        } else {
+          this.io.pinMode(this.pin, this.mode);
+        }
+      }
+    },
+    servoWrite: {
+      value: function(pin, degrees) {
+        // Servo is restricted to integers
+        degrees |= 0;
+
+        // If same degrees, emit "move:complete" and return immediately.
+        if (this.last && this.last.degrees === degrees) {
+          //process.nextTick(this.emit.bind(this, "move:complete"));
+          this.emit("move:complete");
+          return this;
+        }
+
+        this.io.servoWrite(this.pin, degrees);
+
+      }
+    }
+  }
+};
 
 /**
  * Servo
@@ -20,6 +117,7 @@ var SERVOS = [];
 function Servo(opts) {
   var history = [];
   var pinValue;
+  var controller;
 
   if (!(this instanceof Servo)) {
     return new Servo(opts);
@@ -31,6 +129,16 @@ function Servo(opts) {
   Board.Device.call(
     this, opts = Board.Options(opts)
   );
+
+  /**
+   * Used for adding special controllers (i.e. PCA9685)
+   **/
+  controller = typeof opts.controller === "string" ?
+    Controllers[opts.controller] : Controllers.Standard;
+
+  Object.defineProperties(this, controller);
+
+  this.initialize(opts, pinValue);
 
   // StandardFirmata on Arduino allows controlling
   // servos from analog pins.
@@ -54,17 +162,9 @@ function Servo(opts) {
     }
   }
 
-  // When in debug mode, if pin is not a PWM pin, emit an error
-  if (opts.debug && !this.board.pins.isServo(this.pin)) {
-    Board.Pins.Error({
-      pin: this.pin,
-      type: "PWM",
-      via: "Servo",
-    });
-  }
-
   this.id = opts.id || Board.uid();
   this.range = opts.range || [0, 180];
+  this.deadband = opts.deadband || [90, 90];
   this.fps = opts.fps || 100;
   this.offset = opts.offset || 0;
   this.mode = this.io.MODES.SERVO;
@@ -78,12 +178,6 @@ function Servo(opts) {
   // Invert the value of all servoWrite operations
   // eg. 80 => 100, 90 => 90, 0 => 180
   this.isInverted = opts.isInverted || false;
-
-  if (Array.isArray(opts.pwmRange)) {
-    this.io.servoConfig(this.pin, opts.pwmRange[0], opts.pwmRange[1]);
-  } else {
-    this.io.pinMode(this.pin, this.mode);
-  }
 
   // Specification config
   this.specs = opts.specs || {
@@ -136,8 +230,6 @@ function Servo(opts) {
     }
   }
 
-
-
   // If "center" true set servo to 90deg
   if (opts.center) {
     this.center();
@@ -149,6 +241,7 @@ function Servo(opts) {
 }
 
 util.inherits(Servo, Emitter);
+
 
 /**
  * to
@@ -163,9 +256,6 @@ util.inherits(Servo, Emitter);
  */
 
 Servo.prototype.to = function(degrees, time, rate) {
-
-  // Servo is restricted to integers
-  degrees |= 0;
 
   var target = degrees;
 
@@ -186,13 +276,6 @@ Servo.prototype.to = function(degrees, time, rate) {
       this.range[0], this.range[1],
       this.range[1], this.range[0]
     );
-  }
-
-  // If same degrees, emit "move:complete" and return immediately.
-  if (this.last && this.last.degrees === degrees) {
-    process.nextTick(this.emit.bind(this, "move:complete"));
-    // this.emit("move:complete");
-    return this;
   }
 
   if (typeof time !== "undefined") {
@@ -224,7 +307,7 @@ Servo.prototype.to = function(degrees, time, rate) {
         delta *= -1;
       }
 
-      this.io.servoWrite(this.pin, last + delta);
+      this.servoWrite(this.pin, last + delta);
 
       history.push({
         timestamp: Date.now(),
@@ -240,8 +323,7 @@ Servo.prototype.to = function(degrees, time, rate) {
 
   } else {
 
-    this.io.servoWrite(this.pin, degrees);
-
+    this.servoWrite(this.pin, degrees);
     history.push({
       timestamp: Date.now(),
       degrees: degrees,
@@ -428,58 +510,24 @@ Servo.prototype.stop = function() {
   return this;
 };
 
-/** Speeds for continuous rotation
- *
- * Mock directions: A, B
- *
- * 0 Full speed A
- * 89 Slowest speed A
- * 90 Stopped
- * 91 Slowest speed B
- * 180 Fastest speed B
- *
- *
- **/
-
-
-/**
- * Degrees to Pulse lengths in ms
- * Servo.pulse = {
- *   lengths: {
- *     0: 1,
- *     90: 1,
- *     180: 2
- *   },
- *   width: 2 / 180
- * };
- *
- **/
-
-
-[{
-  apis: ["clockWise", "cw"],
-  args: [0, 1, 91, 180]
-}, {
-  apis: ["counterClockwise", "ccw"],
-  args: [0, 1, 89, 0]
-}].forEach(function(setup) {
-  var args = setup.args.slice();
-
-  setup.apis.forEach(function(api) {
-    Servo.prototype[api] = function(rate) {
-      var copy = args.slice();
-      rate = rate === undefined ? 1 : rate;
-
-      if (this.type !== "continuous") {
-        this.board.error(
-          "Servo",
-          "Servo.prototype." + api + " is only available for continuous servos"
-        );
-      }
-      copy.unshift(rate);
-      return this.to(__.scale.apply(null, copy) | 0);
-    };
-  });
+//
+["clockWise", "cw", "counterClockwise", "ccw"].forEach(function(api) {
+  Servo.prototype[api] = function(rate) {
+    var range;
+    rate = rate === undefined ? 1 : rate;
+    if (this.type !== "continuous") {
+      this.board.error(
+        "Servo",
+        "Servo.prototype." + api + " is only available for continuous servos"
+      );
+    }
+    if (api === "cw" || api === "clockWise") {
+      range = [rate, 0, 1, this.deadband[1] + 1, this.range[1]];
+    } else {
+      range = [rate, 0, 1, this.deadband[0] - 1, this.range[0]];
+    }
+    return this.to(__.scale.apply(null, range) | 0);
+  };
 });
 
 
@@ -500,7 +548,6 @@ Servo.Continuous = function(pinOrOpts) {
   }
 
   opts.type = "continuous";
-
   return new Servo(opts);
 };
 

--- a/lib/sleep.js
+++ b/lib/sleep.js
@@ -1,0 +1,6 @@
+module.exports = {
+  nano: function(ns) {
+    var start = process.hrtime();
+    while (process.hrtime() < start + ns) {}
+  }
+};

--- a/programs.json
+++ b/programs.json
@@ -41,6 +41,7 @@
     "servo-diagnostic.js",
     "servo-array.js",
     "boe-test-servos.js",
+    "servo-PCA9685.js",
 
   [ "Motor" ],
     "motor.js",

--- a/test/motor.js
+++ b/test/motor.js
@@ -1163,23 +1163,24 @@ exports["Motor: I2C - PCA9685"] = {
 
   start: function(test) {
     test.expect(6);
+    this.writeSpy.reset();
 
     this.motor.start();
-
     test.equal(this.writeSpy.args[0][0], 0x60);
-    test.equal(this.writeSpy.args[3][1][0], 38);
-    test.equal(this.writeSpy.args[3][1][1], 0);
-    test.equal(this.writeSpy.args[3][1][2], 0);
-    test.equal(this.writeSpy.args[3][1][3], 2048);
-    test.equal(this.writeSpy.args[3][1][4], 8);
+    test.equal(this.writeSpy.args[0][1][0], 38);
+    test.equal(this.writeSpy.args[0][1][1], 0);
+    test.equal(this.writeSpy.args[0][1][2], 0);
+    test.equal(this.writeSpy.args[0][1][3], 2048);
+    test.equal(this.writeSpy.args[0][1][4], 8);
 
     test.done();
   },
 
   stop: function(test) {
     test.expect(6);
-
+    this.writeSpy.reset();
     this.motor.stop();
+
 
     test.equal(this.writeSpy.args[0][0], 0x60);
     test.equal(this.writeSpy.args[0][1][0], 38);
@@ -1193,6 +1194,7 @@ exports["Motor: I2C - PCA9685"] = {
 
   forward: function(test) {
     test.expect(21);
+    this.writeSpy.reset();
 
     this.motor.forward(128);
 
@@ -1219,15 +1221,17 @@ exports["Motor: I2C - PCA9685"] = {
     test.equal(this.writeSpy.args[3][1][0], 38);
     test.equal(this.writeSpy.args[3][1][1], 0);
     test.equal(this.writeSpy.args[3][1][2], 0);
-    test.equal(this.writeSpy.args[3][1][3], 0);
-    test.equal(this.writeSpy.args[3][1][4], 0);
+    test.equal(this.writeSpy.args[3][1][3], 2048);
+    test.equal(this.writeSpy.args[3][1][4], 8);
     test.done();
   },
 
   reverse: function(test) {
     test.expect(21);
+    this.writeSpy.reset();
 
     this.motor.reverse(128);
+
     test.equal(this.writeSpy.args[0][0], 0x60);
 
     test.equal(this.writeSpy.args[0][1][0], 38);
@@ -1239,26 +1243,27 @@ exports["Motor: I2C - PCA9685"] = {
     test.equal(this.writeSpy.args[1][1][0], 46);
     test.equal(this.writeSpy.args[1][1][1], 0);
     test.equal(this.writeSpy.args[1][1][2], 0);
-    test.equal(this.writeSpy.args[1][1][3], 0);
-    test.equal(this.writeSpy.args[1][1][4], 0);
+    test.equal(this.writeSpy.args[1][1][3], 4080);
+    test.equal(this.writeSpy.args[1][1][4], 15);
 
     test.equal(this.writeSpy.args[2][1][0], 42);
     test.equal(this.writeSpy.args[2][1][1], 0);
     test.equal(this.writeSpy.args[2][1][2], 0);
-    test.equal(this.writeSpy.args[2][1][3], 4080);
-    test.equal(this.writeSpy.args[2][1][4], 15);
+    test.equal(this.writeSpy.args[2][1][3], 0);
+    test.equal(this.writeSpy.args[2][1][4], 0);
 
     test.equal(this.writeSpy.args[3][1][0], 38);
     test.equal(this.writeSpy.args[3][1][1], 0);
     test.equal(this.writeSpy.args[3][1][2], 0);
-    test.equal(this.writeSpy.args[3][1][3], 0);
-    test.equal(this.writeSpy.args[3][1][4], 0);
+    test.equal(this.writeSpy.args[3][1][3], 2048);
+    test.equal(this.writeSpy.args[3][1][4], 8);
 
     test.done();
   },
 
   brakeRelease: function(test) {
     test.expect(42);
+    this.writeSpy.reset();
 
     this.motor.rev(128);
     this.writeSpy.reset();
@@ -1394,7 +1399,7 @@ exports["Motor: ShiftRegister"] = {
 
     test.done();
   },
-  
+
   start: function(test) {
     test.expect(1);
 
@@ -1425,7 +1430,7 @@ exports["Motor: ShiftRegister"] = {
     test.ok(this.digitalSpy.getCall(0).calledWith(12, 0)); // Latch 0
     test.ok(this.shiftOutSpy.calledWith(8, 4, true, 0x04));
     test.ok(this.digitalSpy.getCall(25).calledWith(12, 1)); // Latch 1
-    
+
     test.done();
   },
 
@@ -1433,7 +1438,7 @@ exports["Motor: ShiftRegister"] = {
     test.expect(4);
 
     this.motor.reverse(128);
-    
+
     test.ok(this.analogSpy.calledWith(11, 128));
 
     test.ok(this.digitalSpy.getCall(0).calledWith(12, 0)); // Latch 0

--- a/test/servo.js
+++ b/test/servo.js
@@ -343,6 +343,45 @@ exports["Servo - Continuous"] = {
 
     test.done();
   },
+
+  deadband: function(test) {
+    test.expect(2);
+
+    this.continuousServo = new Servo.Continuous({
+      pin: 5,
+      board: board,
+      deadband: [85,95]
+    });
+
+    this.continuousServo.cw(0.5);
+    test.equal(this.continuousServo.value, 138);
+
+    this.continuousServo.ccw(0.5);
+    test.equal(this.continuousServo.value, 42);
+
+    test.done();
+  },
+
+  rangePlusDeadband: function(test) {
+    test.expect(2);
+
+    this.continuousServo = new Servo.Continuous({
+      pin: 5,
+      board: board,
+      deadband: [85,95],
+      range: [20, 160]
+    });
+
+    this.continuousServo.cw();
+    test.ok(this.servoWrite.calledWith(5, 160));
+
+    this.servoWrite.reset();
+
+    this.continuousServo.cw(0.5);
+    test.ok(this.servoWrite.calledWith(5, 128));
+
+    test.done();
+  }
 };
 
 exports["Servo - Allowed Pin Names"] = {
@@ -390,4 +429,43 @@ exports["Servo - Allowed Pin Names"] = {
 
     test.done();
   }
+};
+
+exports["Servo - PCA9685"] = {
+  setUp: function(done) {
+    this.writeSpy = sinon.spy(board.io, "sendI2CWriteRequest");
+    this.readSpy = sinon.spy(board.io, "sendI2CReadRequest");
+    this.servo = new Servo({
+      pin: 0,
+      board: board,
+      controller: "PCA9685",
+      address: 0x40
+    });
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.writeSpy.restore();
+    this.readSpy.restore();
+    done();
+  },
+
+  to: function(test) {
+    test.expect(6);
+    this.writeSpy.reset();
+
+    this.servo.to(20);
+
+    test.equal(this.writeSpy.args[0][0], 0x40);
+    test.equal(this.writeSpy.args[0][1][0], 6);
+    test.equal(this.writeSpy.args[0][1][1], 0);
+    test.equal(this.writeSpy.args[0][1][2], 0);
+    test.equal(this.writeSpy.args[0][1][3], 187);
+    test.equal(this.writeSpy.args[0][1][4], 0);
+
+    test.done();
+
+  }
+
 };


### PR DESCRIPTION
### Adds support for the [Adafruit 16-channel PWM/servo shield](https://learn.adafruit.com/adafruit-16-channel-pwm-slash-servo-shield/overview).

Refactors Servo() to add Controllers (Standard and the PCA9685 which is used on the Adafruit). There was no need to add a Devices object as Servo.Continuous() shares no methods with Servo() and there are no other devices.

```
this.servo = new Servo({
  pin: 0,
  controller: "PCA9685",
  address: 0x41  // Defaults to 0x40
});
```

You can now control 1004 servos :hushed: with Johnny-Five, a single Arduino Uno, and 62 of these shields stacked. 

Addresses #455 
### Adds deadband support for continuous motion servos:

```
this.continuousServo = new Servo.Continuous({
  pin: 5,
  board: board,
  deadband: [85,95]  // Defaults to [90,90]
});
```

I will update the wiki when this lands. I will be drinking :beers: and awaiting nits until then.
