### PR TITLE
Wii.Nunchuck and Wii.Classic can now be called with no parameters

### DIFF
--- a/lib/wii.js
+++ b/lib/wii.js
@@ -653,14 +653,14 @@ Devices = {
 
 Wii.Nunchuk = function(opts) {
   return new Wii({
-    freq: opts.freq || 100,
+    freq: opts && "freq" in opts ? opts.freq : 100,
     device: "RVL-004"
   });
 };
 
 Wii.Classic = function(opts) {
   return new Wii({
-    freq: opts.freq || 100,
+    freq: opts && "freq" in opts ? opts.freq : 100,
     device: "RVL-005"
   });
 };


### PR DESCRIPTION
Creating a new instance of Wii.Nunchuck or Wii.Classic with no parameters was throwing error.

e.g. this

``` javascript
var nunchuk = new five.Wii.Nunchuk();
```

would result in this

```
/Users/derekwheelden/git/johnny-five/lib/wii.js:659
    freq: opts.freq || 100,
              ^
TypeError: Cannot read property 'freq' of undefined
```
