### PR TITLE
Fix Servo.to

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -136,7 +136,7 @@ function Servo(opts) {
   this.offset = opts.offset || 0;
   this.mode = this.io.MODES.SERVO;
   this.interval = null;
-  this.value = 0;
+  this.value = null;
 
   /**
    * Used for adding special controllers (i.e. PCA9685)
@@ -281,6 +281,11 @@ Servo.prototype.to = function(degrees, time, rate) {
     last = this.last && this.last.degrees || 0;
     distance = Math.abs(last - degrees);
     percent = 0;
+
+    if (distance === 0) {
+      process.nextTick(this.emit.bind(this, "move:complete"));
+      return this;
+    }
 
     // If steps are limited by Servo resolution
     if (distance < rate) {

--- a/test/servo.js
+++ b/test/servo.js
@@ -180,6 +180,29 @@ exports["Servo"] = {
     test.done();
   },
 
+  degreeChange: function(test) {
+    test.expect(2);
+
+    this.servo = new Servo({
+      pin: 11,
+      board: board
+    });
+    // We are spying on setInterval instead of servoWrite because the following set of
+    // parameters will result with setInterval will be called with an interval of infinity
+    var spy = sinon.spy(global, "setInterval");
+
+    this.servo.to(180);
+
+    this.servo.to(180, 1000, 100);
+
+    this.clock.tick(1010);
+
+    test.equal(spy.callCount, 0);
+    test.ok(this.servoWrite.callCount,1);
+
+    test.done();
+  },
+
   fps: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Issue:
When calling Servo.to with the same value for degrees twice in a row, the servo wouldn't fail.  Instead it went to 0 degrees.

