### PR TITLE
Add grunt test-docs to ensure docs are up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "0.10"
 compiler: clang
+before_script:
+  - grunt test-docs
 notifications:
   webhooks:
     urls:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,7 @@ require("copy-paste");
 
 var inspect = require("util").inspect;
 var fs = require("fs");
+var shell = require("shelljs");
 
 module.exports = function(grunt) {
 
@@ -315,6 +316,16 @@ module.exports = function(grunt) {
     );
 
     log.writeln("Docs created.");
+  });
+
+  // run the docs task and fail if there are uncommitted changes to the docs directory
+  task.registerTask("test-docs", "Guard against out of date docs", ["docs", "fail-if-uncommitted-docs"]);
+
+  task.registerTask("fail-if-uncommitted-docs", function() {
+    task.requires("docs");
+    if (shell.exec("git diff --exit-code --name-status ./docs").code !== 0) {
+      grunt.fail.fatal("The generated docs don't match the committed docs. Please ensure you've run `grunt docs` before committing.");
+    }
   });
 
   grunt.registerTask("bump", "Bump the version", function(version) {

--- a/docs/ir-distance.md
+++ b/docs/ir-distance.md
@@ -7,12 +7,12 @@ node eg/ir-distance.js
 
 
 ```javascript
-// Run this program with a controller model:
+// Run this program with a device model:
 //
 //    node eg/ir-distance GP2Y0A02YK0F
 //
 //    You may also use the model number printed on the
-//    controller itself. eg
+//    device itself. eg
 //
 //    2Y0A21
 //    2D120X
@@ -48,7 +48,7 @@ board.on("ready", function() {
   distance.on("data", function() {
     if (controller) {
       console.log("inches: ", this.inches);
-      console.log("cm: ", this.centimers, this.raw);
+      console.log("cm: ", this.centimeters, this.raw);
     } else {
       console.log("value: ", this.value);
     }

--- a/package.json
+++ b/package.json
@@ -119,16 +119,17 @@
   "devDependencies": {
     "async": "~0.9.0",
     "copy-paste": "~0.3.0",
-    "optimist": "~0.6.1",
-    "keypress": "latest",
-    "sinon": "~1.10.2",
     "grunt": "~0.4.5",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-jsbeautifier": "~0.2.2",
-    "grunt-jscs": "~0.8.0"
+    "grunt-jscs": "~0.8.0",
+    "keypress": "latest",
+    "optimist": "~0.6.1",
+    "shelljs": "^0.3.0",
+    "sinon": "~1.10.2"
   },
   "scripts": {
     "test": "grunt"


### PR DESCRIPTION
 - Not added to the default task as it relies on your changes to be committed and causes the docs to be generated. This is fine on our CI but not ok in local development.
 - Add to circle as a before_script because of the previous point
 - ir-distance.md was out of date