### PR TITLE
Move debounce function to constructor

### DIFF
--- a/lib/button.js
+++ b/lib/button.js
@@ -9,15 +9,7 @@ var priv = new Map(),
   aliases = {
     down: ["down", "press", "tap", "impact", "hit"],
     up: ["up", "release"]
-  },
-  // Create a 5 ms debounce boundary on event triggers
-  // this avoids button events firing on
-  // press noise and false positives
-  trigger = __.debounce(function(key) {
-    aliases[key].forEach(function(type) {
-      this.emit(type, null);
-    }, this);
-  }, 7);
+  };
 
 
 /**
@@ -39,6 +31,15 @@ function Button(opts) {
   var timeout;
   var pinValue;
   var isFirmata;
+
+  // Create a 5 ms debounce boundary on event triggers
+  // this avoids button events firing on
+  // press noise and false positives
+  var trigger = __.debounce(function(key) {
+    aliases[key].forEach(function(type) {
+      this.emit(type, null);
+    }, this);
+  }, 7);
 
   if (!(this instanceof Button)) {
     return new Button(opts);


### PR DESCRIPTION
Fixes #587 

Prevents “cross-debouncing” of events across button instances.

**Don't merge yet.** - I don't have hardware with me to test.