### PR TITLE
Migrating the Tinkerkit Thermistor to be included in Temperature component

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ board.on("ready", function() {
 - [TinkerKit - Joystick](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-joystick.md)
 - [TinkerKit - Linear Potentiometer](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-linear-pot.md)
 - [TinkerKit - Rotary Potentiometer](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-rotary.md)
+- [TinkerKit -- Temperature](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-thermistor.md)
 - [TinkerKit - Tilt Sensor](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-tilt.md)
 - [TinkerKit - Touch Sensor](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-touch.md)
 

--- a/docs/tinkerkit-thermistor.md
+++ b/docs/tinkerkit-thermistor.md
@@ -1,5 +1,5 @@
 <!--remove-start-->
-# 
+# TinkerKit -- Temperature
 
 Run with:
 ```bash
@@ -8,41 +8,12 @@ node eg/tinkerkit-thermistor.js
 <!--remove-end-->
 
 ```javascript
-var five = require("johnny-five"),
-  Thermistor;
-
-(function() {
-  var adcres, beta, kelvin, rb, ginf;
-
-  adcres = 1023;
-  // Beta parameter
-  beta = 3950;
-  // 0°C = 273.15 K
-  kelvin = 273.15;
-  // 10 kOhm
-  rb = 10000;
-  // Ginf = 1/Rinf
-  ginf = 120.6685;
-
-  Thermistor = {
-    c: function(raw) {
-      var rthermistor, tempc;
-
-      rthermistor = rb * (adcres / raw - 1);
-      tempc = beta / (Math.log(rthermistor * ginf));
-
-      return tempc - kelvin;
-    },
-    f: function(raw) {
-      return (this.c(raw) * 9) / 5 + 32;
-    }
-  };
-}());
+var five = require("johnny-five");
 
 new five.Board().on("ready", function() {
-  new five.Sensor("I0").on("change", function() {
-    console.log("F: ", Thermistor.f(this.value));
-    console.log("C: ", Thermistor.c(this.value));
+  new five.Temperature({controller: "TINKERKIT", pin: "I0"}).on("change", function() {
+    console.log("F: ", this.fahrenheit);
+    console.log("C: ", this.celsius);
   });
 });
 

--- a/eg/tinkerkit-thermistor.js
+++ b/eg/tinkerkit-thermistor.js
@@ -1,38 +1,9 @@
-var five = require("../lib/johnny-five.js"),
-  Thermistor;
-
-(function() {
-  var adcres, beta, kelvin, rb, ginf;
-
-  adcres = 1023;
-  // Beta parameter
-  beta = 3950;
-  // 0°C = 273.15 K
-  kelvin = 273.15;
-  // 10 kOhm
-  rb = 10000;
-  // Ginf = 1/Rinf
-  ginf = 120.6685;
-
-  Thermistor = {
-    c: function(raw) {
-      var rthermistor, tempc;
-
-      rthermistor = rb * (adcres / raw - 1);
-      tempc = beta / (Math.log(rthermistor * ginf));
-
-      return tempc - kelvin;
-    },
-    f: function(raw) {
-      return (this.c(raw) * 9) / 5 + 32;
-    }
-  };
-}());
+var five = require("../lib/johnny-five.js");
 
 new five.Board().on("ready", function() {
-  new five.Sensor("I0").on("change", function() {
-    console.log("F: ", Thermistor.f(this.value));
-    console.log("C: ", Thermistor.c(this.value));
+  new five.Temperature({controller: "TINKERKIT", pin: "I0"}).on("change", function() {
+    console.log("F: ", this.fahrenheit);
+    console.log("C: ", this.celsius);
   });
 });
 

--- a/lib/temperature.js
+++ b/lib/temperature.js
@@ -178,6 +178,25 @@ var Controllers = {
         return tempc;
       }
     }
+  },
+  TINKERKIT: {
+    initialize: {
+      value: analogHandler
+    },
+    toCelsius: {
+      value: function(raw) {
+        var adcres = 1023;
+        var beta = 3950;
+        var kelvin = 273.15;
+        var rb = 10000; // 10 kOhm
+        var ginf = 120.6685; // Ginf = 1/Rinf
+
+        var rthermistor = rb * (adcres / raw - 1);
+        var tempc = beta / (Math.log(rthermistor * ginf));
+
+        return tempc - kelvin;
+      }
+    }
   }
 };
 

--- a/test/temperature.js
+++ b/test/temperature.js
@@ -438,3 +438,46 @@ exports["Temperature -- GROVE"] = {
     test.done();
   }
 };
+
+exports["Temperature -- TINKERKIT"] = {
+
+  setUp: function(done) {
+
+    this.clock = sinon.useFakeTimers();
+    this.analogRead = sinon.spy(board.io, "analogRead");
+    this.temperature = new Temperature({
+      controller: "TINKERKIT",
+      pin: "A0",
+      freq: 100,
+      board: board
+    });
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.analogRead.restore();
+    this.clock.restore();
+    done();
+  },
+
+  data: function(test) {
+
+    var raw = this.analogRead.args[0][1],
+      spy = sinon.spy();
+
+    test.expect(4);
+    this.temperature.on("data", spy);
+
+    raw(810);
+
+    this.clock.tick(100);
+
+    test.ok(spy.calledOnce);
+    test.equals(Math.round(spy.args[0][1].celsius), 39);
+    test.equals(Math.round(spy.args[0][1].fahrenheit), 102);
+    test.equals(Math.round(spy.args[0][1].kelvin), 312);
+
+    test.done();
+  }
+};

--- a/tpl/titles.json
+++ b/tpl/titles.json
@@ -120,6 +120,7 @@
   "tinkerkit-joystick.js": "TinkerKit - Joystick",
   "tinkerkit-linear-pot.js": "TinkerKit - Linear Potentiometer",
   "tinkerkit-rotary.js": "TinkerKit - Rotary Potentiometer",
+  "tinkerkit-thermistor.js": "TinkerKit -- Temperature",
   "tinkerkit-tilt.js": "TinkerKit - Tilt Sensor",
   "tinkerkit-touch.js": "TinkerKit - Touch Sensor",
   "led-blink.js": "LED - Blink",


### PR DESCRIPTION
I was hacking the other day with a Tinkerkit thermistor and I realized that it wasn't ever included in the `Temperature` controllers list.  

- Updated the controllers to include the Tinkerkit
- Updated the example to use the `Temperature` class
- Added the file to `titles.json`.  It was missing and `grunt examples` failed to create the MD because of it.