### PR TITLE
extract jscs config into .jscsrc; resolves #632

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,29 @@
+{
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "try",
+    "catch"
+  ],
+  "disallowNewlineBeforeBlockStatements": true,
+  "requireSpaceBeforeBlockStatements": true,
+  "requireParenthesesAroundIIFE": true,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpaceAfterKeywords": [
+    "if", "else",
+    "switch", "case",
+    "try", "catch",
+    "do", "while", "for",
+    "return", "typeof", "void"
+  ],
+  "validateQuoteMarks": {
+    "mark": "\"",
+    "escape": true
+  },
+  "excludeFiles": [
+    "node_modules/**/*.js"
+  ]
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,41 +108,15 @@ module.exports = function(grunt) {
       }
     },
     jscs: {
-      files: {
-        src: [
-          "Gruntfile.js",
-          "lib/**/!(johnny-five)*.js",
-          "test/**/*.js",
-          "eg/**/*.js",
-        ]
-      },
+      src: [
+        "Gruntfile.js",
+        "lib/**/!(johnny-five)*.js",
+        "test/**/*.js",
+        "eg/**/*.js",
+        "util/**/*.js"
+      ],
       options: {
-        config: ".jscsrc",
-        requireCurlyBraces: [
-          "if",
-          "else",
-          "for",
-          "while",
-          "do",
-          "try",
-          "catch",
-        ],
-        disallowNewlineBeforeBlockStatements: true,
-        requireSpaceBeforeBlockStatements: true,
-        requireParenthesesAroundIIFE: true,
-        requireSpacesInConditionalExpression: true,
-        // requireSpaceBeforeKeywords: true,
-        requireSpaceAfterKeywords: [
-          "if", "else",
-          "switch", "case",
-          "try", "catch",
-          "do", "while", "for",
-          "return", "typeof", "void",
-        ],
-        validateQuoteMarks: {
-          mark: "\"",
-          escape: true
-        }
+        config: ".jscsrc"
       }
     },
     jsbeautifier: {

--- a/util/xbee.js
+++ b/util/xbee.js
@@ -45,18 +45,17 @@ var args = optimist
 
 if (args.help) {
   optimist.showHelp();
-  return process.exit(-1);
+  process.exit(-1);
 }
 
 if (!args.portname) {
   console.error("Serial port name is required. \n `-p /dev/PORTNAME` \n Use one of the following");
-  serialport.list(function(err, data){
-    data.forEach(function(v){
+  serialport.list(function (err, data) {
+    data.forEach(function (v) {
       console.log("\t" + v.comName);
     });
-    return process.exit(-1);
   });
-  return;
+  process.exit(-1);
 }
 
 var guardTime = args.guardtime * 1000;
@@ -76,8 +75,8 @@ var open = function (cb) {
   port.once("open", cb);
 };
 
-var wait = function(ms) {
-  return function(cb) {
+var wait = function (ms) {
+  return function (cb) {
     setTimeout(cb, ms);
   };
 };
@@ -110,16 +109,16 @@ var exit = function () {
   process.exit(0);
 };
 
-var print = function(str) {
-  return function(cb){
+var print = function (str) {
+  return function (cb) {
     console.log(str);
     cb();
   };
 };
 
-var printCmd = function(msg, str) {
+var printCmd = function (msg, str) {
   return function (cb) {
-    readCmd(str + "\r")(function(err, data){
+    readCmd(str + "\r")(function (err, data) {
       console.log(msg + " (" + str + "): " + data);
       cb();
     });


### PR DESCRIPTION
- created `jscs` npm script target; `npm run-script jscs`
- removed JSCS config from `Gruntfile.js`; config now lives in `.jscsrc`
- added `jscs` as devDependency
- added `util/` to paths covered by JSCS
- fixed JSCS errors in `util/xbee.js`
  - a couple formatting problems
  - you can't `return` a `process.exit()` call
  - fixed what appeared to be a logic error when no port name specified; would exit too early
  - the above three issues were reported by JSCS