### PR TITLE
Migrate from colors.js to chalk

### DIFF
--- a/docs/magnetometer-log.md
+++ b/docs/magnetometer-log.md
@@ -8,7 +8,7 @@ node eg/magnetometer-log.js
 <!--remove-end-->
 
 ```javascript
-var color = require("colors"),
+var chalk = require("chalk"),
   five = require("johnny-five"),
   board, colors, servo, mag, count, dirs, lock;
 
@@ -60,11 +60,12 @@ var color = require("colors"),
     // As the heading changes, log heading value
     mag.on("headingchange", function() {
       var log;
+      var color = colors[this.bearing.abbr];
 
       log = (this.bearing.name + " " + Math.floor(this.heading) + "°");
 
       console.log(
-        log[colors[this.bearing.abbr]]
+        chalk[color](log)
       );
 
 

--- a/docs/magnetometer-north.md
+++ b/docs/magnetometer-north.md
@@ -8,9 +8,9 @@ node eg/magnetometer-north.js
 <!--remove-end-->
 
 ```javascript
-var color = require("colors"),
+var chalk = require("chalk"),
   five = require("johnny-five"),
-  board, colors, servo, mag, count, dirs, isNorth, isSeeking, last;
+  board, servo, mag, count, dirs, isNorth, isSeeking, last;
 
 board = new five.Board();
 
@@ -71,7 +71,7 @@ board.on("ready", function() {
       isNorth = false;
 
       if (!isSeeking) {
-        console.log("find north!".red, heading);
+        console.log(chalk.red("find north!"), heading);
         isSeeking = true;
       }
 
@@ -84,41 +84,6 @@ board.on("ready", function() {
     }
   });
 });
-
-colors = {
-  N: "red",
-  NbE: "red",
-  NNE: "red",
-  NEbN: "red",
-  NE: "yellow",
-  NEbE: "yellow",
-  ENE: "yellow",
-  EbN: "yellow",
-  E: "green",
-  EbS: "green",
-  ESE: "green",
-  SEbE: "green",
-  SE: "green",
-  SEbS: "cyan",
-  SSE: "cyan",
-  SbE: "cyan",
-  S: "cyan",
-  SbW: "cyan",
-  SSW: "cyan",
-  SWbS: "blue",
-  SW: "blue",
-  SWbW: "blue",
-  WSW: "blue",
-  WbS: "blue",
-  W: "magenta",
-  WbN: "magenta",
-  WNW: "magenta",
-  NWbW: "magenta",
-  NW: "magenta",
-  NWbN: "magenta",
-  NNW: "magenta",
-  NbW: "red"
-};
 
 ```
 

--- a/eg/magnetometer-log.js
+++ b/eg/magnetometer-log.js
@@ -1,4 +1,4 @@
-var color = require("colors"),
+var chalk = require("chalk"),
   five = require("../lib/johnny-five.js"),
   board, colors, servo, mag, count, dirs, lock;
 
@@ -50,11 +50,12 @@ var color = require("colors"),
     // As the heading changes, log heading value
     mag.on("headingchange", function() {
       var log;
+      var color = colors[this.bearing.abbr];
 
       log = (this.bearing.name + " " + Math.floor(this.heading) + "°");
 
       console.log(
-        log[colors[this.bearing.abbr]]
+        chalk[color](log)
       );
 
 

--- a/eg/magnetometer-north.js
+++ b/eg/magnetometer-north.js
@@ -1,6 +1,6 @@
-var color = require("colors"),
+var chalk = require("chalk"),
   five = require("../lib/johnny-five.js"),
-  board, colors, servo, mag, count, dirs, isNorth, isSeeking, last;
+  board, servo, mag, count, dirs, isNorth, isSeeking, last;
 
 board = new five.Board();
 
@@ -61,7 +61,7 @@ board.on("ready", function() {
       isNorth = false;
 
       if (!isSeeking) {
-        console.log("find north!".red, heading);
+        console.log(chalk.red("find north!"), heading);
         isSeeking = true;
       }
 
@@ -74,38 +74,3 @@ board.on("ready", function() {
     }
   });
 });
-
-colors = {
-  N: "red",
-  NbE: "red",
-  NNE: "red",
-  NEbN: "red",
-  NE: "yellow",
-  NEbE: "yellow",
-  ENE: "yellow",
-  EbN: "yellow",
-  E: "green",
-  EbS: "green",
-  ESE: "green",
-  SEbE: "green",
-  SE: "green",
-  SEbS: "cyan",
-  SSE: "cyan",
-  SbE: "cyan",
-  S: "cyan",
-  SbW: "cyan",
-  SSW: "cyan",
-  SWbS: "blue",
-  SW: "blue",
-  SWbW: "blue",
-  WSW: "blue",
-  WbS: "blue",
-  W: "magenta",
-  WbN: "magenta",
-  WNW: "magenta",
-  NWbW: "magenta",
-  NW: "magenta",
-  NWbN: "magenta",
-  NNW: "magenta",
-  NbW: "red"
-};

--- a/eg/nodeconf-compass.js
+++ b/eg/nodeconf-compass.js
@@ -1,4 +1,4 @@
-var color = require("colors");
+var chalk = require("chalk");
 var five = require("../lib/johnny-five.js");
 var board = new five.Board();
 
@@ -9,8 +9,10 @@ board.on("ready", function() {
 
   // As the heading changes, log heading value
   mag.on("headingchange", function() {
+    var color = colors[this.bearing.abbr];
+
     console.log(
-      (this.bearing.name + " " + Math.floor(this.heading) + "°")[colors[this.bearing.abbr]]
+      chalk[color](this.bearing.name + " " + Math.floor(this.heading) + "°")
     );
   });
 });

--- a/lib/board.js
+++ b/lib/board.js
@@ -5,7 +5,7 @@ var IS_TEST_MODE = global.IS_TEST_MODE || false;
 var Emitter = require("events").EventEmitter;
 var util = require("util");
 // var os = require("os");
-var colors = require("colors");
+var chalk = require("chalk");
 var _ = require("lodash");
 var __ = require("../lib/fn.js");
 var Repl = require("../lib/repl.js");
@@ -543,9 +543,9 @@ Board.prototype.log = function( /* type, module, message [, long description] */
       // Timestamp
       String(+new Date()).grey,
       // Module, color matches type of log
-      module.magenta,
+      chalk.magenta(module),
       // Message
-      message[color],
+      chalk[color](message),
       // Miscellaneous args
       args.join(", ")
     ].join(" "));
@@ -554,7 +554,7 @@ Board.prototype.log = function( /* type, module, message [, long description] */
 
 Board.prototype.log.types = {
   error: "red",
-  fail: "orange",
+  fail: "inverse",
   warn: "yellow",
   info: "cyan"
 };

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "color-convert": "~0.5.2",
-    "colors": ">=0.5.1",
+    "chalk": "latest",
     "descriptor": "latest",
     "ease-component": "latest",
     "es6-shim": "latest",


### PR DESCRIPTION
Related: #626 

Since chalk doesn't support the `orange` color I used the `reverse` for failure messages but I'm open to suggestion on what color to use here, this also fixes a couple of examples using colors and remove some unused colors logic from one example (`eg/magnetometer-north.js`)