### PR TITLE
Add isAnode to LED state. Fixes gh-629

### DIFF
--- a/docs/led-rgb-anode.md
+++ b/docs/led-rgb-anode.md
@@ -21,7 +21,12 @@ board.on("ready", function() {
     isAnode: true
   });
 
-  anode.pulse();
+  anode.strobe();
+
+  this.repl.inject({
+    anode: anode
+  });
+
 });
 
 ```

--- a/docs/led-rgb-anode.md
+++ b/docs/led-rgb-anode.md
@@ -21,7 +21,7 @@ board.on("ready", function() {
     isAnode: true
   });
 
-  anode.strobe();
+  anode.blink();
 
   this.repl.inject({
     anode: anode

--- a/eg/led-rgb-anode.js
+++ b/eg/led-rgb-anode.js
@@ -11,7 +11,7 @@ board.on("ready", function() {
     isAnode: true
   });
 
-  anode.strobe();
+  anode.blink();
 
   this.repl.inject({
     anode: anode

--- a/eg/led-rgb-anode.js
+++ b/eg/led-rgb-anode.js
@@ -11,5 +11,10 @@ board.on("ready", function() {
     isAnode: true
   });
 
-  anode.pulse();
+  anode.strobe();
+
+  this.repl.inject({
+    anode: anode
+  });
+
 });

--- a/lib/led.js
+++ b/lib/led.js
@@ -63,7 +63,7 @@ var Controllers = {
 
         var on, off;
         var state = priv.get(this);
-        var value = state.isAnode ? 255 - Board.constrain(value, 0, 255) : state.value;
+        var value = state.isAnode ? 255 - Board.constrain(state.value, 0, 255) : state.value;
 
         on = 0;
         off = this.pwmRange[1] * value / 255;
@@ -121,7 +121,7 @@ var Controllers = {
           Board.Pins.Error({
             pin: this.pin,
             type: "PWM",
-            via: "Led",
+            via: "Led"
           });
         }
 
@@ -194,7 +194,8 @@ function Led(opts) {
     isRunning: false,
     value: null,
     direction: 1,
-    mode: null
+    mode: null,
+    isAnode: opts.isAnode
   };
 
   priv.set(this, state);
@@ -599,7 +600,8 @@ Led.RGB = function(opts) {
       pin: opts.pins[color],
       board: opts.board,
       address: opts.address,
-      controller: opts.controller
+      controller: opts.controller,
+      isAnode: opts.isAnode
     });
   }
 
@@ -626,6 +628,11 @@ Led.RGB = function(opts) {
     isRunning: {
       get: function() {
         return state.isRunning;
+      }
+    },
+    isAnode: {
+      get: function () {
+        return state.isAnode;
       }
     },
     values: {

--- a/test/led.js
+++ b/test/led.js
@@ -1123,7 +1123,6 @@ exports["Led.RGB - Common Anode"] = {
     };
 
     this.board.io.analogWrite = function(pin, value) {
-      value = 255 - value;
       this.io.analogWrite(pin, value);
     }.bind(this);
 
@@ -1132,27 +1131,37 @@ exports["Led.RGB - Common Anode"] = {
     done();
   },
 
+  isAnode: function (test) {
+    test.expect(1);
+
+    test.equal(this.ledRgb.isAnode, true);
+
+    test.done();
+  },
+
   color: function(test) {
     var redPin = 9,
       greenPin = 10,
       bluePin = 11;
 
-    test.expect(9);
+    test.expect(10);
 
     this.ledRgb.color("#0000ff");
-    test.ok(this.analog.calledWith(redPin, 0xff));
-    test.ok(this.analog.calledWith(greenPin, 0xff));
-    test.ok(this.analog.calledWith(bluePin, 0x00));
+    test.ok(this.analog.calledWith(redPin, 255));
+    test.ok(this.analog.calledWith(greenPin, 255));
+    test.ok(this.analog.calledWith(bluePin, 0));
 
     this.ledRgb.color("#ffff00");
-    test.ok(this.analog.calledWith(redPin, 0x00));
-    test.ok(this.analog.calledWith(greenPin, 0x00));
-    test.ok(this.analog.calledWith(bluePin, 0xff));
+    test.ok(this.analog.calledWith(redPin, 0));
+    test.ok(this.analog.calledWith(greenPin, 0));
+    test.ok(this.analog.calledWith(bluePin, 255));
 
     this.ledRgb.color("#bbccaa");
-    test.ok(this.analog.calledWith(redPin, 0x44));
-    test.ok(this.analog.calledWith(greenPin, 0x33));
-    test.ok(this.analog.calledWith(bluePin, 0x55));
+    test.ok(this.analog.calledWith(redPin, 68));
+    test.ok(this.analog.calledWith(greenPin, 51));
+    test.ok(this.analog.calledWith(bluePin, 85));
+
+    test.equal(this.ledRgb.isAnode, true);
 
     test.done();
   },

--- a/test/led.js
+++ b/test/led.js
@@ -1144,24 +1144,22 @@ exports["Led.RGB - Common Anode"] = {
       greenPin = 10,
       bluePin = 11;
 
-    test.expect(10);
+    test.expect(9);
 
     this.ledRgb.color("#0000ff");
-    test.ok(this.analog.calledWith(redPin, 255));
-    test.ok(this.analog.calledWith(greenPin, 255));
-    test.ok(this.analog.calledWith(bluePin, 0));
+    test.ok(this.analog.calledWith(redPin, 0xff));
+    test.ok(this.analog.calledWith(greenPin, 0xff));
+    test.ok(this.analog.calledWith(bluePin, 0x00));
 
     this.ledRgb.color("#ffff00");
-    test.ok(this.analog.calledWith(redPin, 0));
-    test.ok(this.analog.calledWith(greenPin, 0));
-    test.ok(this.analog.calledWith(bluePin, 255));
+    test.ok(this.analog.calledWith(redPin, 0x00));
+    test.ok(this.analog.calledWith(greenPin, 0x00));
+    test.ok(this.analog.calledWith(bluePin, 0xff));
 
     this.ledRgb.color("#bbccaa");
-    test.ok(this.analog.calledWith(redPin, 68));
-    test.ok(this.analog.calledWith(greenPin, 51));
-    test.ok(this.analog.calledWith(bluePin, 85));
-
-    test.equal(this.ledRgb.isAnode, true);
+    test.ok(this.analog.calledWith(redPin, 0x44));
+    test.ok(this.analog.calledWith(greenPin, 0x33));
+    test.ok(this.analog.calledWith(bluePin, 0x55));
 
     test.done();
   },


### PR DESCRIPTION
* [x] Add `isAnode` to Led and Led.RGB state
* [x] Fix `analogWrite` value bug in PCA9685 controller
* [x] Add test for `isAnode`
* [x] Update docs (Led.RGB has no method `pulse`)

Fixes #629 

Confirmed working with `PCA9685` and `DEFAULT` controllers