### PR TITLE
Revert "Update LED Pulse example"

### DIFF
--- a/docs/led-pulse.md
+++ b/docs/led-pulse.md
@@ -15,7 +15,7 @@ board.on("ready", function() {
 
   // Create a standard `led` component
   // on a valid pwm pin
-  var led = new five.Led(13);
+  var led = new five.Led(9);
 
   led.pulse();
 

--- a/eg/led-pulse.js
+++ b/eg/led-pulse.js
@@ -5,7 +5,7 @@ board.on("ready", function() {
 
   // Create a standard `led` component
   // on a valid pwm pin
-  var led = new five.Led(13);
+  var led = new five.Led(9);
 
   led.pulse();
 


### PR DESCRIPTION
Reverts rwaldron/johnny-five#660 The code was correct. The Fritzing diagram is what was wrong. Pin 13 on Uno is not PWM capable.