### PR TITLE
use environment to declare test mode flag; resolves #669

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,8 @@ var inspect = require("util").inspect;
 var fs = require("fs");
 var shell = require("shelljs");
 
+process.env.IS_TEST_MODE = true;
+
 module.exports = function(grunt) {
 
   var task = grunt.task;
@@ -33,44 +35,8 @@ module.exports = function(grunt) {
       files: ["tpl/programs.json"]
     },
     nodeunit: {
-      tests: [
-        "test/bootstrap.js",
-        "test/board.js",
-        "test/board-connection.js",
-        "test/compass.js",
-        "test/options.js",
-        "test/board.pins.js",
-        "test/board.component.js",
-        "test/capabilities.js",
-        // ------------------
-        "test/accelerometer.js",
-        "test/animation.js",
-        "test/button.js",
-        "test/esc.js",
-        "test/fn.js",
-        "test/gyro.js",
-        "test/imu.js",
-        "test/lcd.js",
-        "test/led.js",
-        "test/ledcontrol.js",
-        "test/motor.js",
-        "test/pin.js",
-        "test/piezo.js",
-        "test/ping.js",
-        "test/pir.js",
-        "test/proximity.js",
-        "test/reflectancearray.js",
-        "test/relay.js",
-        "test/repl.js",
-        "test/sensor.js",
-        "test/servo.js",
-        "test/shiftregister.js",
-        "test/sonar.js",
-        "test/stepper.js",
-        "test/temperature.js",
-        "test/switch.js",
-        "test/wii.js"
-      ]
+      // remove test/distance.js (and this exception) when bumping to 0.9.0
+      tests: ["test/*.js", "!test/mock*", "!test/distance.js"]
     },
     jshint: {
       options: {
@@ -161,11 +127,11 @@ module.exports = function(grunt) {
 
   // Support running a single test suite:
   // grunt nodeunit:just:motor for example
-  grunt.registerTask("nodeunit:just", function(file) {
+  grunt.registerTask("nodeunit:just", "Run a single test specified by a target; usage: \"grunt nodeunit:just:<module-name>[.js]\"", function(file) {
+    var path = require("path");
     if (file) {
       grunt.config("nodeunit.tests", [
-        "test/bootstrap.js",
-        "test/" + file + ".js",
+        path.join("test", path.basename(file, ".js") + ".js")
       ]);
     }
 

--- a/lib/board.js
+++ b/lib/board.js
@@ -1,7 +1,7 @@
 require("es6-shim");
 require("array-includes").shim();
 
-var IS_TEST_MODE = global.IS_TEST_MODE || false;
+var IS_TEST_MODE = !!process.env.IS_TEST_MODE;
 var Emitter = require("events").EventEmitter;
 var util = require("util");
 // var os = require("os");

--- a/lib/esc.js
+++ b/lib/esc.js
@@ -1,4 +1,4 @@
-var IS_TEST_MODE = global.IS_TEST_MODE || false;
+var IS_TEST_MODE = !!process.env.IS_TEST_MODE;
 var Board = require("../lib/board.js");
 var Emitter = require("events").EventEmitter;
 var util = require("util");

--- a/lib/led.js
+++ b/lib/led.js
@@ -1,4 +1,4 @@
-var IS_TEST_MODE = global.IS_TEST_MODE || false;
+var IS_TEST_MODE = !!process.env.IS_TEST_MODE;
 var Board = require("../lib/board.js");
 var __ = require("../lib/fn.js");
 var nanosleep = require("../lib/sleep.js").nano;

--- a/lib/pin.js
+++ b/lib/pin.js
@@ -1,4 +1,4 @@
-var IS_TEST_MODE = global.IS_TEST_MODE || false;
+var IS_TEST_MODE = !!process.env.IS_TEST_MODE;
 var Board = require("../lib/board.js");
 var Descriptor = require("descriptor");
 var __ = require("../lib/fn.js");

--- a/lib/servo.js
+++ b/lib/servo.js
@@ -1,4 +1,4 @@
-var IS_TEST_MODE = global.IS_TEST_MODE || false;
+var IS_TEST_MODE = !!process.env.IS_TEST_MODE;
 var Board = require("../lib/board.js");
 var Pins = Board.Pins;
 var events = require("events");

--- a/test/board.component.js
+++ b/test/board.component.js
@@ -1,6 +1,5 @@
 require("es6-shim");
 
-global.IS_TEST_MODE = true;
 
 var MockFirmata = require("./mock-firmata"),
   five = require("../lib/johnny-five.js"),

--- a/test/board.js
+++ b/test/board.js
@@ -1,6 +1,5 @@
 require("es6-shim");
 
-global.IS_TEST_MODE = true;
 
 var SerialPort = require("./mock-serial").SerialPort,
   MockFirmata = require("./mock-firmata"),

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,1 +1,0 @@
-global.IS_TEST_MODE = true;

--- a/test/pin.js
+++ b/test/pin.js
@@ -1,4 +1,3 @@
-global.IS_TEST_MODE = true;
 
 var five = require("../lib/johnny-five.js"),
   MockFirmata = require("./mock-firmata"),

--- a/test/repl.js
+++ b/test/repl.js
@@ -1,6 +1,5 @@
 require("es6-shim");
 
-global.IS_TEST_MODE = true;
 
 var SerialPort = require("./mock-serial").SerialPort,
   MockFirmata = require("./mock-firmata"),


### PR DESCRIPTION
- Relevant files check `process.env.IS_TEST_MODE` instead of a global prop
- The value of `IS_TEST_MODE` is assumed to be a boolean
- Individual suites do not set `IS_TEST_MODE`
- `bootstrap.js` is no longer necessary and has been removed
- `Gruntfile.js` sets the `IS_TEST_MODE` flag; as long as you run the tests via `npm test` or `grunt`, your environment will be correct.  Otherwise, you must manually set the `IS_TEST_MODE` environment variable.
- simplified test targets within `Gruntfile.js` with globs
- remove `bootstrap.js` reference within `nodeunit:just`; while I was in there, corrected a potential Windows incompatibility, made slightly more flexible, and documented it for use with `grunt --help`

Happy to remove the changes I snuck into `Gruntfile.js` if you wish.