### PR TITLE
reduce total size of dependencies by cherry-picking LoDash functions

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -6,7 +6,6 @@ var Emitter = require("events").EventEmitter;
 var util = require("util");
 // var os = require("os");
 var chalk = require("chalk");
-var _ = require("lodash");
 var __ = require("../lib/fn.js");
 var Repl = require("../lib/repl.js");
 var Options = require("../lib/board.options.js");
@@ -215,7 +214,7 @@ function Board(opts) {
 
   // Initialize this Board instance with
   // param specified properties.
-  _.assign(this, opts);
+  Object.assign(this, opts);
 
   this.timer = null;
 
@@ -880,7 +879,7 @@ Board.Event = function(opts) {
 
   // Initialize this Board instance with
   // param specified properties.
-  _.assign(this, opts);
+  Object.assign(this, opts);
 };
 
 

--- a/lib/board.options.js
+++ b/lib/board.options.js
@@ -1,5 +1,3 @@
-var _ = require("lodash");
-
 /**
  * Options
  *
@@ -29,7 +27,7 @@ function Options(arg) {
     opts = arg;
   }
 
-  _.assign(this, opts);
+  Object.assign(this, opts);
 }
 
 module.exports = Options;

--- a/lib/fn.js
+++ b/lib/fn.js
@@ -1,14 +1,14 @@
-var lodash = require("lodash"),
-  Fn = {
-    assign: lodash.assign,
-    extend: lodash.extend,
-    defaults: lodash.defaults,
-    debounce: lodash.debounce,
-    cloneDeep: lodash.cloneDeep,
-    mixin: lodash.mixin,
-    every: lodash.every,
-    pluck: lodash.pluck
-  };
+var Fn = {
+  assign: Object.assign,
+  extend: Object.assign,
+  defaults: require("defaults"),
+  debounce: require("lodash.debounce"),
+  cloneDeep: require("lodash.clonedeep"),
+  mixin: require("lodash.mixin"),
+  every: require("lodash.every"),
+  pluck: require("lodash.pluck"),
+  contains: require("lodash.includes")
+};
 
 // Fn.fmap( val, fromLow, fromHigh, toLow, toHigh )
 //

--- a/package.json
+++ b/package.json
@@ -110,10 +110,16 @@
     "descriptor": "latest",
     "ease-component": "latest",
     "es6-shim": "latest",
-    "lodash": "latest",
     "nanotimer": "0.3.1",
     "temporal": "latest",
-    "array-includes": "latest"
+    "array-includes": "latest",
+    "defaults": "latest",
+    "lodash.clonedeep": "latest",
+    "lodash.debounce": "latest",
+    "lodash.every": "latest",
+    "lodash.includes": "latest",
+    "lodash.mixin": "latest",
+    "lodash.pluck": "latest"
   },
   "optionalDependencies": {
     "firmata": ">=0.2.9",

--- a/test/board.js
+++ b/test/board.js
@@ -8,7 +8,6 @@ var SerialPort = require("./mock-serial").SerialPort,
   Repl = require("../lib/repl"),
   sinon = require("sinon"),
   __ = require("../lib/fn.js"),
-  _ = require("lodash"),
   Board = five.Board,
   board = new Board({
     io: new MockFirmata(),
@@ -172,7 +171,7 @@ exports["instance"] = {
 
   cache: function(test) {
     test.expect(1);
-    test.ok(_.contains(five.Board.cache, board));
+    test.ok(__.contains(five.Board.cache, board));
     test.done();
   },
 


### PR DESCRIPTION
- instances of `_.assign()` become `Object.assign()`
- remove dependency `lodash`
- add dependencies:
  - `lodash.clonedeep`
  - `lodash.debounce`
  - `lodash.mixin`
  - `lodash.every`
  - `lodash.pluck`
  - `lodash.includes`
  - `defaults` (smaller than the LoDash counterpart)
- added `lodash.includes` to `fn.js` (`__`) as `contains`

I'm not sure if this is worth the bother, as it saves us around one (1) MB, however it's setting a good precedent for future contributors--they'll know that j5 doesn't use LoDash proper.