### PR TITLE
Fixes to servo

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -261,11 +261,10 @@ Servo.prototype.to = function(degrees, time, rate) {
 
   var target = degrees;
 
-  degrees += this.offset;
-
   // Enforce limited range of motion
   degrees = Board.constrain(degrees, this.range[0], this.range[1]);
 
+  degrees += this.offset;
   this.value = degrees;
 
   var last, distance, percent;
@@ -275,8 +274,8 @@ Servo.prototype.to = function(degrees, time, rate) {
   if (this.invert) {
     degrees = Board.map(
       degrees,
-      this.range[0], this.range[1],
-      this.range[1], this.range[0]
+      0, 180,
+      180, 0
     );
   }
 

--- a/test/servo.js
+++ b/test/servo.js
@@ -161,6 +161,160 @@ exports["Servo"] = {
     test.done();
   },
 
+  range: function(test) {
+    test.expect(3);
+
+    this.servo = new Servo({
+      pin: 11,
+      board: board,
+      range: [20, 160]
+    });
+
+    this.servo.to(180);
+
+    test.ok(this.servoWrite.calledWith(11, 160));
+
+    this.servo.to(135);
+
+    test.ok(this.servoWrite.calledWith(11, 135));
+
+    this.servo.to(10);
+
+    test.ok(this.servoWrite.calledWith(11, 20));
+
+    test.done();
+  },
+
+  rangeWithInvert: function(test) {
+    test.expect(3);
+
+    this.servo = new Servo({
+      pin: 11,
+      board: board,
+      invert: true,
+      range: [30, 160]
+    });
+
+    this.servo.to(180);
+
+    test.ok(this.servoWrite.calledWith(11, 20));
+
+    this.servo.to(135);
+
+    test.ok(this.servoWrite.calledWith(11, 45));
+
+    this.servo.to(10);
+
+    test.ok(this.servoWrite.calledWith(11, 150));
+
+    test.done();
+  },
+
+  offset: function(test) {
+    test.expect(3);
+
+    this.servo = new Servo({
+      pin: 11,
+      board: board,
+      offset: -10
+    });
+
+    this.servo.to(180);
+
+    test.ok(this.servoWrite.calledWith(11, 170));
+
+    this.servo.to(135);
+
+    test.ok(this.servoWrite.calledWith(11, 125));
+
+    this.servo.to(10);
+
+    test.ok(this.servoWrite.calledWith(11, 0));
+
+    test.done();
+  },
+
+  offsetWithInvert: function(test) {
+    test.expect(3);
+
+    this.servo = new Servo({
+      pin: 11,
+      board: board,
+      offset: -10,
+      invert: true
+    });
+
+    this.servo.to(180);
+
+    test.ok(this.servoWrite.calledWith(11, 10));
+
+    this.servo.to(135);
+
+    test.ok(this.servoWrite.calledWith(11, 55));
+
+    this.servo.to(10);
+
+    test.ok(this.servoWrite.calledWith(11, 180));
+
+    test.done();
+  },
+
+  offsetWithRange: function(test) {
+    test.expect(3);
+
+    this.servo = new Servo({
+      pin: 11,
+      board: board,
+      offset: -10,
+      range: [20, 150]
+    });
+
+    this.servo.to(180);
+
+    test.ok(this.servoWrite.calledWith(11, 140));
+
+    this.servo.to(135);
+
+    test.ok(this.servoWrite.calledWith(11, 125));
+
+    this.servo.to(10);
+
+    test.ok(this.servoWrite.calledWith(11, 10));
+
+    test.done();
+  },
+
+  offsetWithRangeAndInvert: function(test) {
+    test.expect(3);
+
+    this.servo = new Servo({
+      pin: 11,
+      board: board,
+      offset: -10,
+      range: [20, 150],
+      invert: true
+    });
+
+    this.servo.to(180);
+
+    test.ok(this.servoWrite.calledWith(11, 40));
+
+    this.servo.to(135);
+
+    test.ok(this.servoWrite.calledWith(11, 55));
+
+    this.servo.to(10);
+
+    test.ok(this.servoWrite.calledWith(11, 170));
+
+    test.done();
+  },
+
+  /*
+  offset - range - invert
+  1 - 1 - 1
+  */
+
   rate: function(test) {
     test.expect(2);
 
@@ -180,7 +334,7 @@ exports["Servo"] = {
     test.done();
   },
 
-  completeMoveEmmitted: function(test) {
+  completeMoveEmitted: function(test) {
     test.expect(1);
 
     this.servo = new Servo({


### PR DESCRIPTION
Addresses #666

1) Range was being constrained after offset was applied which was
wrong. User should not have to think in two different coordinate spaces.
2) Invert was based on global coordinate range which led to incorrect
values being passed to the servo. Invert has to be based on the
physical range of the servo in local coordinate space. We need to
track two ranges, the global coordinate range for ease of use and the
physical device range of the servo. We are assuming 180° servos for
now. We will have to add in 45° and 270° servos as Devices.
3) Added tests