### PR TITLE
Support auto-calibration for reflectance array

### DIFF
--- a/lib/reflectancearray.js
+++ b/lib/reflectancearray.js
@@ -60,6 +60,10 @@ function onData(sensorState, value) {
   if (allRead) {
     this.emit("data", null, this.raw);
 
+    if (state.autoCalibrate) {
+      setCalibration(state.calibration, this.raw);
+    }
+
     if (this.isCalibrated) {
       this.emit("calibratedData", null, this.values);
       this.emit("line", null, this.line);
@@ -69,6 +73,18 @@ function onData(sensorState, value) {
       sensorState.dataReceived = false;
     });
   }
+}
+
+function setCalibration(calibration, values) {
+  values.forEach(function(value, i) {
+    if (calibration.min[i] === undefined || value < calibration.min[i]) {
+      calibration.min[i] = value;
+    }
+
+    if (calibration.max[i] === undefined || value > calibration.max[i]) {
+      calibration.max[i] = value;
+    }
+  });
 }
 
 function calibrationIsValid(calibration, sensors) {
@@ -145,7 +161,8 @@ function ReflectanceArray(opts) {
     calibration: {
       min: [],
       max: []
-    }
+    },
+    autoCalibrate: opts.autoCalibrate || false
   };
 
   priv.set(this, state);
@@ -224,15 +241,7 @@ ReflectanceArray.prototype.calibrate = function() {
   var state = priv.get(this);
 
   this.once("data", function(err, values) {
-    values.forEach(function(value, i) {
-      if (state.calibration.min[i] === undefined || value < state.calibration.min[i]) {
-        state.calibration.min[i] = value;
-      }
-
-      if (state.calibration.max[i] === undefined || value > state.calibration.max[i]) {
-        state.calibration.max[i] = value;
-      }
-    });
+    setCalibration(state.calibration, values);
 
     this.emit("calibrated");
   });


### PR DESCRIPTION
Instead of an explicit calibration step, or the requirement to load a calibration file, setting `autoCalibrate: true` will cause the unit to always be calibrating.  This will make the learning curve on the sensor to be less steep because they don't need to worry about calibrating.  Instead, as long as the unit is reading data, it will be setting the min/max.  This will also help in environments like Robotnik, where the pre-ready code becomes awkward.

Users can still tweak the calibration by using the original mechanism.  This is just easier with less control.  

We are using a similar mechanism in the `Accelerometer`, and I was quite fond of it after it was complete.