### PR TITLE
Multi ds18b20

### DIFF
--- a/docs/temperature-ds18b20.md
+++ b/docs/temperature-ds18b20.md
@@ -19,6 +19,7 @@ five.Board().on("ready", function() {
 
   temperature.on("data", function(err, data) {
     console.log(data.celsius + "°C", data.fahrenheit + "°F");
+    console.log("0x" + this.address.toString(16));
   });
 });
 

--- a/eg/temperature-ds18b20.js
+++ b/eg/temperature-ds18b20.js
@@ -9,6 +9,7 @@ five.Board().on("ready", function() {
 
   temperature.on("data", function(err, data) {
     console.log(data.celsius + "°C", data.fahrenheit + "°F");
+    console.log("0x" + this.address.toString(16));
   });
 });
 

--- a/eg/temperature-dual-ds18b20.js
+++ b/eg/temperature-dual-ds18b20.js
@@ -1,0 +1,29 @@
+var five = require("../lib/johnny-five");
+
+five.Board().on("ready", function() {
+  // This requires OneWire support using the ConfigurableFirmata
+  var temperatureA = new five.Temperature({
+    controller: "DS18B20",
+    pin: 2,
+    address: 0x687f1fe
+  });
+
+  var temperatureB = new five.Temperature({
+    controller: "DS18B20",
+    pin: 2,
+    address: 0x6893a41
+  });
+
+
+  temperatureA.on("data", function(err, data) {
+    console.log("A", data.celsius + "°C", data.fahrenheit + "°F");
+  });
+
+  temperatureB.on("data", function(err, data) {
+    console.log("B", data.celsius + "°C", data.fahrenheit + "°F");
+  });
+});
+
+// @markdown
+// - [DS18B20 - Temperature Sensor](http://www.maximintegrated.com/en/products/analog/sensors-and-sensor-interface/DS18S20.html)
+// @markdown

--- a/lib/fn.js
+++ b/lib/fn.js
@@ -7,8 +7,7 @@ var lodash = require("lodash"),
     cloneDeep: lodash.cloneDeep,
     mixin: lodash.mixin,
     every: lodash.every,
-    pluck: lodash.pluck,
-    contains: lodash.contains
+    pluck: lodash.pluck
   };
 
 // Fn.fmap( val, fromLow, fromHigh, toLow, toHigh )

--- a/lib/fn.js
+++ b/lib/fn.js
@@ -7,7 +7,8 @@ var lodash = require("lodash"),
     cloneDeep: lodash.cloneDeep,
     mixin: lodash.mixin,
     every: lodash.every,
-    pluck: lodash.pluck
+    pluck: lodash.pluck,
+    contains: lodash.contains
   };
 
 // Fn.fmap( val, fromLow, fromHigh, toLow, toHigh )

--- a/lib/temperature.js
+++ b/lib/temperature.js
@@ -57,6 +57,10 @@ var Drivers = {
             return;
           }
 
+          this.devices.forEach(function(device) {
+            this.emit("initialized", getAddress(device));
+          }.bind(this));
+
           readTemperature = function() {
             var devicesToRead, result;
 
@@ -106,7 +110,7 @@ var Drivers = {
             readOne();
           }.bind(this);
 
-          setTimeout(readTemperature, freq);
+          readTemperature();
         }.bind(this));
       }
     },
@@ -141,6 +145,9 @@ Drivers.get = function(board, driverName, opts) {
   return drivers[driverName];
 };
 
+Drivers.clear = function() {
+  activeDrivers.clear();
+};
 
 // References
 //
@@ -189,8 +196,15 @@ var Controllers = {
           driver = Drivers.get(this.board, "DS18B20", opts);
 
         if (address) {
+          state.address = address;
           driver.register(address);
         }
+
+        driver.once("initialized", function(dataAddress) {
+          if (!state.address) {
+            state.address = dataAddress;
+          }
+        });
 
         driver.on("data", function(dataAddress, data) {
           if (!address || dataAddress === address) {
@@ -355,5 +369,7 @@ function Temperature(opts) {
 }
 
 util.inherits(Temperature, Emitter);
+
+Temperature.Drivers = Drivers;
 
 module.exports = Temperature;

--- a/lib/temperature.js
+++ b/lib/temperature.js
@@ -198,6 +198,11 @@ var Controllers = {
         if (address) {
           state.address = address;
           driver.register(address);
+        } else {
+          if (driver.addressless) {
+            this.emit("error", "You cannot have more than one DS18B20 without an address");
+          }
+          driver.addressless = true;
         }
 
         driver.once("initialized", function(dataAddress) {

--- a/lib/temperature.js
+++ b/lib/temperature.js
@@ -1,6 +1,5 @@
 var Board = require("../lib/board.js"),
   Emitter = require("events").EventEmitter,
-  __ = require("../lib/fn.js"),
   util = require("util");
 
 
@@ -68,7 +67,7 @@ var Drivers = {
             if (this.addresses) {
               devicesToRead = this.devices.filter(function(device) {
                 var address = getAddress(device);
-                return __.contains(this.addresses, address);
+                return this.addresses.includes(address);
               }, this);
             } else {
               devicesToRead = [this.devices[0]];

--- a/lib/temperature.js
+++ b/lib/temperature.js
@@ -1,5 +1,6 @@
 var Board = require("../lib/board.js"),
   Emitter = require("events").EventEmitter,
+  __ = require("../lib/fn.js"),
   util = require("util");
 
 
@@ -11,6 +12,135 @@ function analogHandler(opts, dataHandler) {
     dataHandler.call(this, data);
   }.bind(this));
 }
+
+var activeDrivers = new Map();
+
+var Drivers = {
+  DS18B20: {
+    initialize: {
+      value: function(board, opts) {
+        var CONSTANTS = {
+          TEMPERATURE_FAMILY: 0x28,
+          CONVERT_TEMPERATURE_COMMAND: 0x44,
+          READ_SCRATCHPAD_COMMAND: 0xBE,
+          READ_COUNT: 2
+        },
+          pin = opts.pin,
+          freq = opts.freq || 100,
+          getAddress, readTemperature, readOne;
+          
+        getAddress = function(device) {
+          // 64-bit device code
+          // device[0]    => Family Code
+          // device[1..6] => Serial Number (device[1] is LSB)
+          // device[7]    => CRC
+          var i, result = 0;
+          for (i = 6; i > 0; i--) {
+            result = result * 256 + device[i];
+          }
+          return result;
+        };
+
+        board.io.sendOneWireConfig(pin, true);
+        board.io.sendOneWireSearch(pin, function(err, devices) {
+          if (err) {
+            this.emit("error", err);
+            return;
+          }
+
+          this.devices = devices.filter(function(device) {
+            return device[0] === CONSTANTS.TEMPERATURE_FAMILY;
+          }, this);
+
+          if (devices.length === 0) {
+            this.emit("error", new Error("FAILED TO FIND TEMPERATURE DEVICE"));
+            return;
+          }
+
+          readTemperature = function() {
+            var devicesToRead, result;
+
+            // request tempeature conversion
+            if (this.addresses) {
+              devicesToRead = this.devices.filter(function(device) {
+                var address = getAddress(device);
+                return __.contains(this.addresses, address);
+              }, this);
+            } else {
+              devicesToRead = [this.devices[0]];
+            }
+
+            devicesToRead.forEach(function(device) {
+              board.io.sendOneWireReset(pin);
+              board.io.sendOneWireWrite(pin, device, CONSTANTS.CONVERT_TEMPERATURE_COMMAND);
+            });
+
+            // the delay gives the sensor time to do the calculation
+            board.io.sendOneWireDelay(pin, 1);
+
+            readOne = function() {
+              var device;
+
+              if (devicesToRead.length === 0) {
+                setTimeout(readTemperature, freq);
+                return;
+              }
+
+              device = devicesToRead.pop();
+              // read from the scratchpad
+              board.io.sendOneWireReset(pin);
+
+              board.io.sendOneWireWriteAndRead(pin, device, CONSTANTS.READ_SCRATCHPAD_COMMAND, CONSTANTS.READ_COUNT, function(err, data) {
+                if (err) {
+                  this.emit("error", err);
+                  return;
+                }
+
+                result = (data[1] << 8) | data[0];
+                this.emit("data", getAddress(device), result);
+
+                readOne();
+              }.bind(this));
+            }.bind(this);
+
+            readOne();
+          }.bind(this);
+
+          setTimeout(readTemperature, freq);
+        }.bind(this));
+      }
+    },
+    register: {
+      value: function(address) {
+        if (!this.addresses) {
+          this.addresses = [];
+        }
+
+        this.addresses.push(address);
+      }
+    }
+  }
+};
+
+Drivers.get = function(board, driverName, opts) {
+  var drivers, driverKey, driver;
+
+  if (!activeDrivers.has(board)) {
+    activeDrivers.set(board, {});
+  }
+
+  drivers = activeDrivers.get(board);
+
+  if (!drivers[driverName]) {
+    driver = new Emitter();
+    Object.defineProperties(driver, Drivers[driverName]);
+    driver.initialize(board, opts);
+    drivers[driverName] = driver;
+  }
+
+  return drivers[driverName];
+};
+
 
 // References
 //
@@ -54,74 +184,18 @@ var Controllers = {
   DS18B20: {
     initialize: {
       value: function(opts, dataHandler) {
-        var CONSTANTS = {
-          TEMPERATURE_FAMILY: 0x28,
-          CONVERT_TEMPERATURE_COMMAND: 0x44,
-          READ_SCRATCHPAD_COMMAND: 0xBE,
-          READ_COUNT: 2
-        },
-          pin = opts.pin,
-          freq = opts.freq || 100,
+        var state = priv.get(this),
           address = opts.address,
-          state = priv.get(this),
-          device, getAddress, readTemperature;
+          driver = Drivers.get(this.board, "DS18B20", opts);
 
-        getAddress = function(device) {
-          // 64-bit device code
-          // device[0]    => Family Code
-          // device[1..6] => Serial Number (device[1] is LSB)
-          // device[7]    => CRC
-          var i, result = 0;
-          for (i = 6; i > 0; i--) {
-            result = result * 256 + device[i];
+        if (address) {
+          driver.register(address);
+        }
+
+        driver.on("data", function(dataAddress, data) {
+          if (!address || dataAddress === address) {
+            dataHandler(data);
           }
-          return result;
-        };
-
-        this.io.sendOneWireConfig(pin, true);
-        this.io.sendOneWireSearch(pin, function(err, devices) {
-          if (err) {
-            this.emit("error", err);
-            return;
-          }
-
-          devices = devices.filter(function(device) {
-            var inFamily = device[0] === CONSTANTS.TEMPERATURE_FAMILY;
-            var isAddress = address === undefined || getAddress(device) === address;
-
-            return inFamily && isAddress;
-          }, this);
-
-          if (devices.length === 0) {
-            this.emit("error", new Error("FAILED TO FIND TEMPERATURE DEVICE"));
-            return;
-          }
-
-          device = devices[0];
-          state.address = getAddress(device);
-
-          readTemperature = function() {
-            // request tempeature conversion
-            this.io.sendOneWireReset(pin);
-            this.io.sendOneWireWrite(pin, device, CONSTANTS.CONVERT_TEMPERATURE_COMMAND);
-
-            // the delay gives the sensor time to do the calculation
-            this.io.sendOneWireDelay(pin, 1);
-
-            // read from the scratchpad
-            this.io.sendOneWireReset(pin);
-            this.io.sendOneWireWriteAndRead(pin, device, CONSTANTS.READ_SCRATCHPAD_COMMAND, CONSTANTS.READ_COUNT, function(err, data) {
-              if (err) {
-                this.emit("error", err);
-                return;
-              }
-
-              dataHandler((data[1] << 8) | data[0]);
-              setTimeout(readTemperature, freq);
-            });
-          }.bind(this);
-
-          readTemperature();
         }.bind(this));
       }
     },

--- a/test/temperature.js
+++ b/test/temperature.js
@@ -269,6 +269,54 @@ exports["Temperature -- DS18B20"] = {
     test.equals(this.temperature.address, 0x554433221100);
 
     test.done();
+  },
+
+  twoAddressedUnits: function(test) {
+    var spyA = sinon.spy();
+    var spyB = sinon.spy();
+    var deviceA = [0x28, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0xFF];
+    var deviceB = [0x28, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0xFF];
+    var search, data;
+
+    test.expect(2);
+
+    this.temperatureA = createDS18B20(this.pin, 0x554433221100);
+    this.temperatureA.on("data", spyA);
+    this.temperatureB = createDS18B20(this.pin, 0x050403020100);
+    this.temperatureB.on("data", spyB);
+
+    search = this.sendOneWireSearch.args[0][1];
+    search(null, [deviceA, deviceB]);
+
+    data = this.sendOneWireWriteAndRead.args[0][4];
+    data(null, [0x01, 0x02]);
+    data = this.sendOneWireWriteAndRead.args[1][4];
+    data(null, [0x03, 0x04]);
+
+    this.clock.tick(100);
+
+    test.equals(Math.round(spyA.args[0][1].celsius), 32);
+    test.equals(Math.round(spyB.args[0][1].celsius), 64);
+
+    test.done();
+  },
+
+  twoAddresslessUnitsThrowsError: function(test) {
+    var failedToCreate = false;
+
+    test.expect(1);
+
+    this.temperature = createDS18B20(this.pin);
+
+    try {
+      createDS18B20(this.pin);
+    } catch (err) {
+      failedToCreate = true;
+    }
+
+    test.equals(failedToCreate, true);
+
+    test.done();
   }
 };
 

--- a/test/temperature.js
+++ b/test/temperature.js
@@ -182,6 +182,7 @@ exports["Temperature -- DS18B20"] = {
     this.sendOneWireWrite.restore();
     this.sendOneWireWriteAndRead.restore();
     this.clock.restore();
+    Temperature.Drivers.clear();
     done();
   },
 


### PR DESCRIPTION
This is to fix the bug https://github.com/rwaldron/johnny-five/issues/692

In order to support more than one DS18B20 OneWire sensors, we need to coordinate the OneWire requests to read so that they aren't clobbering each other.  I'm using the "Driver" approach that we used with the IMU where there may be multiple components/controllers, but they all use the same instance of a "driver" to coordinate a single resource.  In the case of the IMU, it was the single-unit I2C board.  In the case of this OneWire device, it is the OneWire bus itself.

I'm going to do a bit more manual testing tonight to make sure everything is good, but I think this code is solid enough for a PR.  I'll make minor tweaks if necessary.