### PR TITLE
Restore ability to have Servo.Arrays be elements of Servo.Arrays

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -580,7 +580,7 @@ Servo.Array = function(numsOrObjects) {
   if (numsOrObjects) {
     while (numsOrObjects.length) {
       var numOrObject = numsOrObjects.shift();
-      if (!(numOrObject instanceof Servo)) {
+      if (!(numOrObject instanceof Servo || numOrObject instanceof Servo.Array)) {
         numOrObject = new Servo(numOrObject);
       }
       items.push(numOrObject);

--- a/test/servo.js
+++ b/test/servo.js
@@ -806,4 +806,29 @@ exports["Servo.Array"] = {
     test.done();
   },
 
+  arrayOfArrays: function(test) {
+    test.expect(9);
+
+    var servos = new Servo.Array([this.a, this.b]);
+    var arrayOfArrays = new Servo.Array([servos, this.c]);
+
+    arrayOfArrays.to(90);
+
+    test.equal(this.to.callCount, 3);
+    test.equal(this.to.getCall(0).args[0], 90);
+    test.equal(this.to.getCall(1).args[0], 90);
+    test.equal(this.to.getCall(2).args[0], 90);
+
+    test.equal(arrayOfArrays.length, 2);
+    test.equal(arrayOfArrays[0][0], this.a);
+    test.equal(arrayOfArrays[0][1], this.b);
+    test.equal(arrayOfArrays[1], this.c);
+
+    arrayOfArrays.stop();
+
+    test.equal(this.stop.callCount, 3);
+
+    test.done();
+  }
+
 };


### PR DESCRIPTION
This got lost in 89be18da167c798ac9ec4fd27da371488c794e84

I'm using this ability liberally in complex Animation() scripts including my examples in the book.