### PR TITLE
Led: Clear interval after animation

### DIFF
--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -338,9 +338,10 @@ Led.prototype.animate = function(opts) {
     opts.step(delta);
 
     if (progress === 1) {
+      this.stop();
       opts.complete();
     }
-  }, opts.delay || 10);
+  }.bind(this), opts.delay || 10);
 
   return this;
 };
@@ -420,7 +421,6 @@ Led.prototype.fade = function(val, time, callback) {
   }.bind(this);
 
   var complete = function() {
-    this.stop();
     if (typeof callback === "function") {
       callback();
     }

--- a/test/led.js
+++ b/test/led.js
@@ -347,6 +347,38 @@ exports["Led - PWM (Analog)"] = {
     test.done();
   },
 
+  animate: function(test) {
+    sinon.spy(global, "setInterval");
+    sinon.spy(this.led, "stop");
+    test.expect(10);
+
+    var step = sinon.spy(),
+      complete = sinon.spy();
+
+    this.led.off();
+    test.equal(this.led.interval, null);
+
+    this.led.animate({
+      step: step,
+      duration: 1000,
+      complete: complete
+    });
+    test.equal(setInterval.callCount, 1);
+    test.equal(setInterval.args[0][1], 10);
+    test.ok(this.led.interval);
+
+    this.clock.tick(1000);
+    test.equal(step.callCount, 100);
+    test.equal(step.args[0][0], 0.01);
+    test.equal(step.args[50][0], 0.51);
+    test.equal(step.args[99][0], 1);
+    test.equal(this.led.stop.calledOnce, true);
+    test.equal(complete.calledOnce, true);
+
+    setInterval.restore();
+    test.done();
+  },
+
   pulse: function(test) {
     sinon.spy(global, "clearInterval");
     sinon.spy(global, "setInterval");


### PR DESCRIPTION
Animation intervals weren't cleared until another animation started or `.stop()` was called. As a result, once the animation completed, the interval would keep running and the `step` and `complete` callbacks would be called repeatedly.
