### PR TITLE
Pass callback to next iteration of .pulse()

### DIFF
--- a/lib/led.js
+++ b/lib/led.js
@@ -379,7 +379,7 @@ Led.prototype.pulse = function(time, callback) {
   }.bind(this);
 
   var complete = function() {
-    this.pulse(time);
+    this.pulse(time, callback);
     if (typeof callback === "function") {
       callback();
     }


### PR DESCRIPTION
The callback was only called the first time the pulse completed.