### PR TITLE
Led animate args

### DIFF
--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -366,7 +366,7 @@ Led.prototype.pulse = function(time, callback) {
 
   if (typeof time === "function") {
     callback = time;
-    time = 1000;
+    time = null;
   }
 
   var step = function(delta) {
@@ -391,7 +391,7 @@ Led.prototype.pulse = function(time, callback) {
   }.bind(this);
 
   return this.animate({
-    duration: time || 1000,
+    duration: time,
     complete: complete,
     step: step
   });
@@ -413,7 +413,7 @@ Led.prototype.fade = function(val, time, callback) {
 
   if (typeof time === "function") {
     callback = time;
-    time = 1000;
+    time = null;
   }
 
   var step = function(delta) {
@@ -432,7 +432,7 @@ Led.prototype.fade = function(val, time, callback) {
   }.bind(this);
 
   return this.animate({
-    duration: time || 1000,
+    duration: time,
     complete: complete,
     step: step
   });

--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -316,6 +316,10 @@ Led.prototype.animate = function(opts) {
     clearInterval(this.interval);
   }
 
+  if (!opts.duration) {
+    opts.duration = 1000;
+  }
+
   if (!opts.delta) {
     opts.delta = function(val) {
       return val;
@@ -338,7 +342,9 @@ Led.prototype.animate = function(opts) {
     opts.step(delta);
 
     if (progress === 1) {
-      opts.complete();
+      if (typeof opts.complete === "function") {
+        opts.complete();
+      }
     }
   }, opts.delay || 10);
 

--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -325,7 +325,6 @@ Led.prototype.animate = function(opts) {
       return val;
     };
   }
-  // TODO: Give opts.step a default
 
   state.isRunning = true;
 


### PR DESCRIPTION
Ref #715

I split this into three commits to make it easier to back out changes if we don't want all of these.

* f3655b650ead829fbf6de86006c0707184a4f032 implements the defaults agreed upon in #715.
* c5f3e879ee9258ef8c58c6ede35ff56ae93791f0 removes the TODO about having a default `step`. If you're calling `.animate()`, you should define what animation you want.
* 4385875405da5976d70bfcb96a68b533321bc1bd removes the explicit default duration for methods that use `.animate()`, falling back to the new default inside `.animate()` (same value as before).

I'll squash these once there's agreement on what should stay. This will need to be rebased once #710 lands anyway.