### PR TITLE
Led: Add a callback for .blink()

### DIFF
--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -446,7 +446,7 @@ Led.prototype.fadeOut = function(time, callback) {
  * @param  {Number} rate Time in ms to strobe/blink
  * @return {Led}
  */
-Led.prototype.strobe = function(rate) {
+Led.prototype.strobe = function(rate, callback) {
   var isHigh = false;
   var state = priv.get(this);
 
@@ -455,10 +455,18 @@ Led.prototype.strobe = function(rate) {
     clearInterval(this.interval);
   }
 
+  if (typeof rate === "function") {
+    callback = rate;
+    rate = null;
+  }
+
   state.isRunning = true;
 
   this.interval = setInterval(function() {
     this.toggle();
+    if (typeof callback === "function") {
+      callback();
+    }
   }.bind(this), rate || 100);
 
   return this;

--- a/test/led.js
+++ b/test/led.js
@@ -158,7 +158,9 @@ exports["Led - Digital"] = {
   },
 
   strobe: function(test) {
-    test.expect(3);
+    test.expect(7);
+
+    var spy;
 
     this.led.off();
     this.led.strobe(100);
@@ -170,6 +172,24 @@ exports["Led - Digital"] = {
     this.led.stop();
     this.clock.tick(100);
     test.equal(this.digitalWrite.callCount, 3);
+
+    this.led.stop().off();
+    spy = sinon.spy();
+    this.led.strobe(100, spy);
+
+    this.clock.tick(100);
+    test.equal(spy.callCount, 1);
+    this.clock.tick(100);
+    test.equal(spy.callCount, 2);
+
+    this.led.stop().off();
+    spy = sinon.spy();
+    this.led.strobe(spy);
+
+    this.clock.tick(100);
+    test.equal(spy.callCount, 1);
+    this.clock.tick(100);
+    test.equal(spy.callCount, 2);
 
     test.done();
   },


### PR DESCRIPTION
Ref #716 

Note that the callback is invoked after the LED is toggled, and we're using `setInterval()`, not nested `setTimeout()`, so the possible drift mentioned in https://github.com/rwaldron/johnny-five/issues/716#issuecomment-91623969 is unlikely to occur.