### PR TITLE
Wii: Remove check for opts existing before use

### DIFF
--- a/lib/wii.js
+++ b/lib/wii.js
@@ -73,8 +73,8 @@ function Wii(opts) {
   this.freq = opts.freq || 500;
 
   // Button instance properties
-  this.holdtime = opts && opts.holdtime || 500;
-  this.threshold = opts && opts.threshold || 10;
+  this.holdtime = opts.holdtime || 500;
+  this.threshold = opts.threshold || 10;
 
   // Initialize components
   device.initialize.call(this);


### PR DESCRIPTION
There are uses of `opts` which require it to exist prior to these lines, so the guard isn't necessary.