### PR TITLE
stepper max per board; err if no dir; tests

### DIFF
--- a/lib/stepper.js
+++ b/lib/stepper.js
@@ -1,9 +1,9 @@
-var Board = require("../lib/board.js"),
-  events = require("events"),
-  util = require("util");
+var Board = require("../lib/board.js");
+var events = require("events");
+var util = require("util");
 
-var priv = new Map(),
-  steppers = [];
+var priv = new Map();
+var steppers = new Map();
 
 var MAXSTEPPERS = 6; // correlates with MAXSTEPPERS in firmware
 
@@ -60,7 +60,7 @@ function isSupported(io) {
  *  type: five.Stepper.TYPE.DRIVER
  *  stepsPerRev: number,
  *  pins: {
- *    step: number
+ *    step: number,
  *    dir: number
  *  }
  * });
@@ -109,7 +109,7 @@ function isSupported(io) {
  */
 
 function Stepper(opts) {
-  var initial, params = [];
+  var state, params = [];
 
   if (!(this instanceof Stepper)) {
     return new Stepper(opts);
@@ -134,10 +134,11 @@ function Stepper(opts) {
   if (!opts.stepsPerRev) {
     throw new Error(
       "Stepper requires a `stepsPerRev` number value"
-    );
+      );
   }
 
-  this.id = steppers.length;
+  steppers.set(this.board, steppers.get(this.board) || []);
+  this.id = steppers.get(this.board).length;
 
   if (this.id >= MAXSTEPPERS) {
     throw new Error(
@@ -188,7 +189,7 @@ function Stepper(opts) {
   if (opts.type === Stepper.TYPE.DRIVER) {
     if (!this.pins.dir || !this.pins.step) {
       throw new Error(
-        "Stepper.TYPE.DRIVER expects: pins.dir, pins.step"
+        "Stepper.TYPE.DRIVER expects: `pins.dir`, `pins.step`"
       );
     }
 
@@ -200,7 +201,7 @@ function Stepper(opts) {
   if (opts.type === Stepper.TYPE.TWO_WIRE) {
     if (!this.pins.motor1 || !this.pins.motor2) {
       throw new Error(
-        "Stepper.TYPE.TWO_WIRE expects: pins.motor1, pins.motor2"
+        "Stepper.TYPE.TWO_WIRE expects: `pins.motor1`, `pins.motor2`"
       );
     }
 
@@ -212,7 +213,7 @@ function Stepper(opts) {
   if (opts.type === Stepper.TYPE.FOUR_WIRE) {
     if (!this.pins.motor1 || !this.pins.motor2 || !this.pins.motor3 || !this.pins.motor4) {
       throw new Error(
-        "Stepper.TYPE.FOUR_WIRE expects: pins.motor1, pins.motor2, pins.motor3, pins.motor4"
+        "Stepper.TYPE.FOUR_WIRE expects: `pins.motor1`, `pins.motor2`, `pins.motor3`, `pins.motor4`"
       );
     }
 
@@ -231,15 +232,31 @@ function Stepper(opts) {
 
   this.io.stepperConfig.apply(this.io, params);
 
-  steppers.push(this);
+  steppers.get(this.board).push(this);
 
-  initial = Step.PROPERTIES.reduce(function(state, key, i) {
+  state = Step.PROPERTIES.reduce(function(state, key, i) {
     return (state[key] = typeof opts[key] !== "undefined" ? opts[key] : Step.DEFAULTS[i], state);
   }, {
-    isRunning: false
+    isRunning: false,
+    type: opts.type,
+    pins: this.pins
   });
 
-  priv.set(this, initial);
+  priv.set(this, state);
+
+  Object.defineProperties(this, {
+    type: {
+      get: function() {
+        return state.type;
+      }
+    },
+
+    pins: {
+      get: function() {
+        return state.pins;
+      }
+    }
+  });
 }
 
 Object.defineProperties(Stepper, {
@@ -368,9 +385,9 @@ Stepper.prototype.step = function(stepsOrOpts, callback) {
 
   isValidStep = true;
 
-  function failback() {
+  function failback(error) {
     isValidStep = false;
-    callback();
+    if (callback) { callback(error); }
   }
 
   params.push(steps);
@@ -400,13 +417,17 @@ Stepper.prototype.step = function(stepsOrOpts, callback) {
 
   if (steps === 0) {
     failback(
-      new Error("Must set a number of steps")
+      new Error(
+        "Must set a number of steps when calling `step()`"
+      )
     );
   }
 
   if (step.direction < 0) {
     failback(
-      new Error("Must set a direction")
+      new Error(
+        "Must set a direction before calling `step()`"
+      )
     );
   }
 

--- a/test/stepper.js
+++ b/test/stepper.js
@@ -49,17 +49,451 @@ exports["Stepper Firmware Requirement"] = {
       repl: false
     });
 
-    test.throws(function() {
+    try {
       new Stepper({
         board: this.board,
         type: five.Stepper.TYPE.DRIVER,
         stepsPerRev: 200,
         pins: [2, 3]
       });
+    } catch (error) {
+      test.equals(error.message, "Stepper is not supported");
+    }
+
+    test.done();
+  },
+};
+
+exports["Stepper - constructor"] = {
+  setUp: function(done) {
+
+    this.board = new Board({
+      io: new MockFirmata({
+        pins: [
+          {
+            supportedModes: [8]
+          }
+        ]
+      }),
+      debug: false,
+      repl: false
+    });
+
+    done();
+  },
+  tearDown: function(done) {
+    done();
+  },
+
+  inferTypeAmbiguous: function(test) {
+    test.expect(1);
+
+    try {
+      var stepper = new Stepper({
+        board: this.board,
+        stepsPerRev: 200,
+        pins: [2, 3]
+      });
+    } catch ( error ) {
+      test.equals(error.message, "Stepper requires a `type` number value (DRIVER, TWO_WIRE)");
+    }
+
+    test.done();
+  },
+
+  inferTypeDriver: function(test) {
+    test.expect(2);
+    var pins = {
+      step: 2,
+      dir: 3
+    };
+    var stepper = new Stepper({
+      board: this.board,
+      stepsPerRev: 200,
+      pins: pins
+    });
+    test.equal(stepper.type, Stepper.TYPE.DRIVER);
+    test.deepEqual(stepper.pins, pins);
+
+    test.done();
+  },
+
+  inferType2Wire: function(test) {
+    test.expect(2);
+    var pins = {
+      motor1: 3,
+      motor2: 4
+    };
+    var stepper = new Stepper({
+      board: this.board,
+      stepsPerRev: 200,
+      pins: pins
+    });
+    test.equal(stepper.type, Stepper.TYPE.TWO_WIRE);
+    test.deepEqual(stepper.pins, pins);
+
+    test.done();
+  },
+
+  inferType4Wire: function(test) {
+    test.expect(2);
+    var pins = {
+      motor1: 2,
+      motor2: 3,
+      motor3: 4,
+      motor4: 5
+    };
+    var stepper = new Stepper({
+      board: this.board,
+      stepsPerRev: 200,
+      pins: pins
+    });
+    test.equal(stepper.type, Stepper.TYPE.FOUR_WIRE);
+    test.deepEqual(stepper.pins, pins);
+
+    test.done();
+  },
+
+  typeDevice: function(test) {
+    test.expect(4);
+    var pins = {
+      step: 2,
+      dir: 3
+    };
+    var stepper = new Stepper({
+      board: this.board,
+      type: five.Stepper.TYPE.DRIVER,
+      stepsPerRev: 200,
+      pins: pins
+    });
+
+    test.equal(stepper.type, Stepper.TYPE.DRIVER);
+    test.deepEqual(stepper.pins, pins);
+
+    pins = [3, 4];
+    stepper = new Stepper({
+      board: this.board,
+      type: five.Stepper.TYPE.DRIVER,
+      stepsPerRev: 200,
+      pins: pins
+    });
+
+    test.equal(stepper.type, Stepper.TYPE.DRIVER);
+    test.deepEqual(
+      stepper.pins,
+      {step: pins[0], dir: pins[1]}
+    );
+
+    test.done();
+  },
+
+  type2Wire: function(test) {
+    test.expect(4);
+    var pins = {
+      motor1: 2,
+      motor2: 3
+    };
+    var stepper = new Stepper({
+      board: this.board,
+      type: five.Stepper.TYPE.TWO_WIRE,
+      stepsPerRev: 200,
+      pins: pins
+    });
+
+    test.equal(stepper.type, Stepper.TYPE.TWO_WIRE);
+    test.deepEqual(stepper.pins, pins);
+
+    pins = [3, 4];
+    stepper = new Stepper({
+      board: this.board,
+      type: five.Stepper.TYPE.TWO_WIRE,
+      stepsPerRev: 200,
+      pins: pins
+    });
+
+    test.equal(stepper.type, Stepper.TYPE.TWO_WIRE);
+    test.deepEqual(
+      stepper.pins,
+      {motor1: pins[0], motor2: pins[1]}
+    );
+
+    test.done();
+  },
+
+  type4Wire: function(test) {
+    test.expect(4);
+    var pins = {
+      motor1: 2,
+      motor2: 3,
+      motor3: 4,
+      motor4: 5
+    };
+    var stepper = new Stepper({
+      board: this.board,
+      type: five.Stepper.TYPE.FOUR_WIRE,
+      stepsPerRev: 200,
+      pins: pins
+    });
+
+    test.equal(stepper.type, Stepper.TYPE.FOUR_WIRE);
+    test.deepEqual(stepper.pins, pins);
+
+    pins = [3, 4, 5, 6];
+    stepper = new Stepper({
+      board: this.board,
+      type: five.Stepper.TYPE.FOUR_WIRE,
+      stepsPerRev: 200,
+      pins: pins
+    });
+
+    test.equal(stepper.type, Stepper.TYPE.FOUR_WIRE);
+    test.deepEqual(
+      stepper.pins,
+      {motor1: pins[0], motor2: pins[1], motor3: pins[2], motor4: pins[3]}
+    );
+
+    test.done();
+  }
+};
+
+exports["Stepper - max steppers"] = {
+  setUp: function(done) {
+
+    this.maxSteppers = 6;
+
+    this.board1 = new Board({
+      io: new MockFirmata({
+        pins: [
+          {
+            supportedModes: [8]
+          }
+        ]
+      }),
+      debug: false,
+      repl: false
+    });
+
+    this.board2 = new Board({
+      io: new MockFirmata({
+        pins: [
+          {
+            supportedModes: [8]
+          }
+        ]
+      }),
+      debug: false,
+      repl: false
+    });
+
+    done();
+  },
+
+  tearDown: function(done) {
+    done();
+  },
+
+  singleBoard: function(test) {
+    test.expect(2);
+
+    test.doesNotThrow(function() {
+      for (var i = 0; i < this.maxSteppers; i++) {
+        new Stepper({
+          board: this.board1,
+          stepsPerRev: 200,
+          pins: [3, 4, 5, 6]
+        });
+      }
+    }.bind(this));
+
+    test.throws(function() {
+      new Stepper({
+        board: this.board1,
+        stepsPerRev: 200,
+        pins: [3, 4, 5, 6]
+      });
     }.bind(this));
 
     test.done();
   },
+
+  multipleBoards: function(test) {
+    test.expect(3);
+
+    // should be able to add max on two boards
+    test.doesNotThrow(function() {
+      for (var i = 0; i < this.maxSteppers; i++) {
+        new Stepper({
+          board: this.board1,
+          stepsPerRev: 200,
+          pins: [2, 3, 4, 5]
+        });
+        new Stepper({
+          board: this.board2,
+          stepsPerRev: 200,
+          pins: [2, 3, 4, 5]
+        });
+      }
+    }.bind(this));
+
+    // but can't add any more to either board
+    test.throws(function() {
+      new Stepper({
+        board: this.board1,
+        stepsPerRev: 200,
+        pins: [2, 3, 4, 5]
+      });
+    }.bind(this));
+
+    test.throws(function() {
+      new Stepper({
+        board: this.board2,
+        stepsPerRev: 200,
+        pins: [2, 3, 4, 5]
+      });
+    }.bind(this));
+
+    test.done();
+  }
+};
+
+exports["Stepper - step callback"] = {
+  setUp: function(done) {
+    this.board = new Board({
+      io: new MockFirmata({
+        pins: [
+          {
+            supportedModes: [8]
+          }
+        ]
+      }),
+      debug: false,
+      repl: false
+    });
+
+    this.stepper = new Stepper({
+      board: this.board,
+      type: five.Stepper.TYPE.DRIVER,
+      stepsPerRev: 200,
+      pins: [2, 3]
+    });
+
+    this.step = sinon.spy(this.board.io, "stepperStep");
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.step.restore();
+    done();
+  },
+
+  step: function(test) {
+    var spy = sinon.spy();
+
+    test.expect(1);
+    
+    this.stepper.cw().step(1, spy);
+    // simulate successful callback from board.io
+    this.step.args[0][6]();
+
+    // test that callback called up the chain to .step()
+    test.equal(spy.getCall(0).args[0], null);
+    test.done();
+  }
+};
+
+exports["Stepper - set direction required before step"] = {
+  setUp: function(done) {
+
+    this.board = new Board({
+      io: new MockFirmata({
+        pins: [
+          {
+            supportedModes: [8]
+          }
+        ]
+      }),
+      debug: false,
+      repl: false
+    });
+
+    this.stepper = new Stepper({
+      board: this.board,
+      type: five.Stepper.TYPE.DRIVER,
+      stepsPerRev: 200,
+      pins: [2, 3]
+    });
+    
+    this.stepperStep = sinon.spy(this.board.io, "stepperStep");
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.stepperStep.restore();
+    done();
+  },
+
+  directionSet: function(test) {
+    var spy = sinon.spy();
+
+    test.expect(2);
+
+    // Call .step() before and after setting direction
+    this.stepper.step(1, spy);
+    this.stepper.cw();
+    this.stepper.step(1, spy);
+
+    // simulate callback on success for second call
+    // Note, stepper should error out before this.stepperStep()
+    // is called before direction is set, thus args[0] here.
+    this.stepperStep.args[0][6]();
+
+    test.ok(!!spy.getCall(0).args[0]);
+    test.ok(!spy.getCall(1).args[0]);
+
+    test.done();
+  }
+};
+
+exports["Stepper - chainable direction"] = {
+  setUp: function(done) {
+
+    this.board = new Board({
+      io: new MockFirmata({
+        pins: [
+          {
+            supportedModes: [8]
+          }
+        ]
+      }),
+      debug: false,
+      repl: false
+    });
+
+    this.stepper = new Stepper({
+      board: this.board,
+      type: five.Stepper.TYPE.DRIVER,
+      stepsPerRev: 200,
+      pins: [2, 3]
+    });
+
+    done();
+  },
+
+  tearDown: function(done) {
+    done();
+  },
+
+  chainable: function(test) {
+    test.expect(2);
+
+    // .cw() and .ccw() return `this`
+    test.equal(this.stepper.cw(), this.stepper);
+    test.equal(this.stepper.ccw(), this.stepper);
+
+    test.done();
+  }
 };
 
 exports["Stepper - rpm / speed"] = {
@@ -86,6 +520,7 @@ exports["Stepper - rpm / speed"] = {
     });
     done();
   },
+
   tearDown: function(done) {
     this.pinMode.restore();
     done();
@@ -109,5 +544,5 @@ exports["Stepper - rpm / speed"] = {
     this.stepper.speed(1885);
     test.equal(this.stepper.rpm(), 180);
     test.done();
-  },
+  }
 };


### PR DESCRIPTION
Fixes #739 - limits max steppers (currently 6) per board instead of global
Fixes #736 - returns error object to callback function