### PR TITLE
Minor cleanup for Board.Options

### DIFF
--- a/lib/board.options.js
+++ b/lib/board.options.js
@@ -15,15 +15,13 @@ function Options(arg) {
     return new Options(arg);
   }
 
-  var isArray = Array.isArray(arg);
   var opts = {};
 
   if (typeof arg === "number" ||
-    typeof arg === "string" ||
-    Array.isArray(arg)) {
-    // Arrays are on a "pins" property
-    // String/Numbers are on a "pin" property
-    opts[isArray ? "pins" : "pin"] = arg;
+    typeof arg === "string") {
+    opts.pin = arg;
+  } else if (Array.isArray(arg)) {
+    opts.pins = arg;
   } else {
     opts = arg;
   }


### PR DESCRIPTION
I noticed that `Array.isArray(arg)` was called multiple times, even though the result was already stored in a variable. I was about to just swap out the function call for the existing variable when I realized that the logic would be more clear by just adding another conditional.