### PR TITLE
Remove an unused spy in the motor tests

### DIFF
--- a/test/motor.js
+++ b/test/motor.js
@@ -1095,7 +1095,6 @@ exports["Motor: I2C - PCA9685"] = {
   setUp: function(done) {
     this.board = newBoard();
     this.writeSpy = sinon.spy(this.board.io, "i2cWrite");
-    this.readSpy = sinon.spy(this.board.io, "i2cRead");
     this.motor = new Motor({
       board: this.board,
       pins: [8, 9, 10],


### PR DESCRIPTION
I noticed this when looking at cb14000c9440c2b3c8b77fa636f063597c53571c.