### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,12 +95,7 @@
   "bugs": {
     "url": "https://github.com/rwaldron/johnny-five/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/rwaldron/johnny-five/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "lib/johnny-five",
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/