### PR TITLE
Led.RGB: Refactor to device/controller model

### DIFF
--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -166,16 +166,14 @@ function Led(opts) {
 
   Object.defineProperties(this, controller);
 
-  // LED instance properties
-  this.interval = null;
-
   state = {
     isOn: false,
     isRunning: false,
     value: null,
     direction: 1,
     mode: null,
-    isAnode: opts.isAnode
+    isAnode: opts.isAnode,
+    interval: null
   };
 
   priv.set(this, state);
@@ -233,7 +231,7 @@ Led.prototype.on = function() {
     }
 
     // ...there is no active interval
-    if (!this.interval) {
+    if (!state.interval) {
       state.value = 255;
     }
 
@@ -437,8 +435,8 @@ Led.prototype.strobe = function(rate, callback) {
   var state = priv.get(this);
 
   // Avoid traffic jams
-  if (this.interval) {
-    clearInterval(this.interval);
+  if (state.interval) {
+    clearInterval(state.interval);
   }
 
   if (typeof rate === "function") {
@@ -448,7 +446,7 @@ Led.prototype.strobe = function(rate, callback) {
 
   state.isRunning = true;
 
-  this.interval = setInterval(function() {
+  state.interval = setInterval(function() {
     this.toggle();
     if (typeof callback === "function") {
       callback();
@@ -467,7 +465,7 @@ Led.prototype.blink = Led.prototype.strobe;
 Led.prototype.stop = function() {
   var state = priv.get(this);
 
-  clearInterval(this.interval);
+  clearInterval(state.interval);
 
   if (state.animation) {
     state.animation.stop();

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -1,12 +1,117 @@
-var Led = require("./led"),
-  priv = new Map();
+var Board = require("../board.js");
+var nanosleep = require("../sleep.js").nano;
+
+var priv = new Map();
+
+var Controllers = {
+  DEFAULT: {
+    initialize: {
+      value: function(opts) {
+        RGB.colors.forEach(function(color, index) {
+          var pin = opts.pins[index];
+
+          if (!this.board.pins.isPwm(pin)) {
+            Board.Pins.Error({
+              pin: pin,
+              type: "PWM",
+              via: "Led.RGB"
+            });
+          }
+
+          this.io.pinMode(pin, this.io.MODES.PWM);
+          this.pins[index] = pin;
+        }, this);
+      }
+    },
+    write: {
+      value: function(colors) {
+        var state = priv.get(this);
+
+        RGB.colors.forEach(function(color, index) {
+          var pin = this.pins[index];
+          var value = colors[color];
+
+          if (state.isAnode) {
+            value = 255 - Board.constrain(value, 0, 255);
+          }
+
+          this.io.analogWrite(pin, value);
+        }, this);
+
+        Object.assign(state, colors);
+      }
+    }
+  },
+  PCA9685: {
+    COMMANDS: {
+      value: {
+        PCA9685_MODE1: 0x0,
+        PCA9685_PRESCALE: 0xFE,
+        LED0_ON_L: 0x6
+      }
+    },
+    initialize: {
+      value: function(opts) {
+        this.address = opts.address || 0x40;
+
+        if (!this.board.Drivers[this.address]) {
+          this.io.i2cConfig();
+          this.board.Drivers[this.address] = {
+            initialized: false
+          };
+
+          // Reset
+          this.io.i2cWrite(this.address, [this.COMMANDS.PCA9685_MODE1, 0x0]);
+          // Sleep
+          this.io.i2cWrite(this.address, [this.COMMANDS.PCA9685_MODE1, 0x10]);
+          // Set prescalar
+          this.io.i2cWrite(this.address, [this.COMMANDS.PCA9685_PRESCALE, 0x70]);
+          // Wake up
+          this.io.i2cWrite(this.address, [this.COMMANDS.PCA9685_MODE1, 0x0]);
+          // Wait 5 nanoseconds for restart
+          nanosleep(5);
+          // Auto-increment
+          this.io.i2cWrite(this.address, [this.COMMANDS.PCA9685_MODE1, 0xa1]);
+
+          this.board.Drivers[this.address].initialized = true;
+        }
+
+        RGB.colors.forEach(function(color, index) {
+          var pin = opts.pins[index];
+          this.pins[index] = pin;
+        }, this);
+      }
+    },
+    write: {
+      value: function(colors) {
+        var state = priv.get(this);
+
+        RGB.colors.forEach(function(color, index) {
+          var pin = this.pins[index];
+          var value = colors[color];
+          var on, off;
+
+          if (state.isAnode) {
+            value = 255 - Board.constrain(value, 0, 255);
+          }
+
+          on = 0;
+          off = value * 4095 / 255;
+
+          this.io.i2cWrite(this.address, [this.COMMANDS.LED0_ON_L + 4 * pin, on, on >> 8, off, off >> 8]);
+        }, this);
+
+        Object.assign(state, colors);
+      }
+    }
+  }
+};
 
 /**
- * LedRGB
+ * RGB
+ * @constructor
  *
- *
- * @param  {[type]} opts [description]
- * @return {[type]}      [description]
+ * @param {Object} opts [description]
  * @alias Led.RGB
  */
 var RGB = function(opts) {
@@ -15,47 +120,43 @@ var RGB = function(opts) {
   }
 
   var state;
+  var controller;
 
   if (Array.isArray(opts)) {
     // RGB([Byte, Byte, Byte]) shorthand
-    // Convert to opts.pins object definition
+    // Convert to opts.pins array definition
     opts = {
-      pins: {
-        red: opts[0],
-        green: opts[1],
-        blue: opts[2]
-      }
+      pins: opts
     };
-  } else {
-    // If opts.pins is an array, convert to object
-    if (Array.isArray(opts.pins)) {
-      opts.pins = {
-        red: opts.pins[0],
-        green: opts.pins[1],
-        blue: opts.pins[2]
-      };
-    }
+  // If opts.pins is an object, convert to array
+  } else if (typeof opts.pins === "object" && !Array.isArray(opts.pins)) {
+    opts.pins = [opts.pins.red, opts.pins.green, opts.pins.blue];
   }
 
-  // Initialize each Led instance
-  RGB.colors.forEach(function(color) {
-    this[color] = new Led({
-      pin: opts.pins[color],
-      board: opts.board,
-      address: opts.address,
-      controller: opts.controller,
-      isAnode: opts.isAnode
-    });
-  }.bind(this));
+  Board.Component.call(
+    this, opts = Board.Options(opts)
+  );
+
+  if (opts.controller && typeof opts.controller === "string") {
+    controller = Controllers[opts.controller.toUpperCase()];
+  } else {
+    controller = opts.controller;
+  }
+
+  if (controller == null) {
+    controller = Controllers["DEFAULT"];
+  }
+
+  Object.defineProperties(this, controller);
 
   this.interval = null;
 
+  // The default color is #ffffff, but the light will be off
   state = {
     red: 255,
     green: 255,
     blue: 255,
-    isAnode: opts.isAnode || false,
-    isRunning: false
+    isAnode: opts.isAnode || false
   };
 
   priv.set(this, state);
@@ -64,13 +165,13 @@ var RGB = function(opts) {
     isOn: {
       get: function() {
         return RGB.colors.some(function(color) {
-          return this[color].isOn;
-        }, this);
+          return state[color] > 0;
+        });
       }
     },
     isRunning: {
       get: function() {
-        return state.isRunning;
+        return !!this.interval;
       }
     },
     isAnode: {
@@ -81,11 +182,14 @@ var RGB = function(opts) {
     values: {
       get: function() {
         return RGB.colors.reduce(function(current, color) {
-          return (current[color] = this[color].value, current);
-        }.bind(this), {});
+          return (current[color] = state[color], current);
+        }, {});
       }
     }
   });
+
+  this.initialize(opts);
+  this.off();
 };
 
 RGB.colors = ["red", "green", "blue"];
@@ -101,46 +205,44 @@ RGB.colors = ["red", "green", "blue"];
 */
 RGB.prototype.color = function(red, green, blue) {
   var state = priv.get(this);
-  var input, update;
-
-  update = {
-    red: null,
-    green: null,
-    blue: null
-  };
+  var update = {};
+  var input;
+  var colors;
 
   if (arguments.length === 0) {
-    // Return a "copy" of the state values,
+    // Return a copy of the state values,
     // not a reference to the state object itself.
-    return Led.RGB.colors.reduce(function(current, color) {
-      return (current[color] = state[color], current);
+    colors = this.isOn ? state : state.prev;
+    return RGB.colors.reduce(function(current, color) {
+      return (current[color] = colors[color], current);
     }, {});
   }
 
   if (arguments.length === 1) {
     input = red;
 
-    if (input === null || input === undefined) {
+    if (input == null) {
       throw new Error("Led.RGB.color: invalid color (" + input + ")");
     }
 
-    if (typeof input === "object") {
-
-      if (Array.isArray(input)) {
+    if (Array.isArray(input)) {
         // color([Byte, Byte, Byte])
-        update.red = input[0];
-        update.green = input[1];
-        update.blue = input[2];
-      } else {
+        update = {
+          red: input[0],
+          green: input[1],
+          blue: input[2]
+        };
+    } else if (typeof input === "object") {
         // colors({
         //   red: Byte,
         //   green: Byte,
         //   blue: Byte
         // });
-        update.red = input.red;
-        update.green = input.green;
-        update.blue = input.blue;
-      }
+        update = {
+          red: input.red,
+          green: input.green,
+          blue: input.blue
+        };
     } else if (typeof input === "string") {
       // color("#ffffff")
       if (input.length === 7 && input[0] === "#") {
@@ -152,53 +254,65 @@ RGB.prototype.color = function(red, green, blue) {
       }
 
       // color("ffffff")
-      update.red = parseInt(input.slice(0, 2), 16);
-      update.green = parseInt(input.slice(2, 4), 16);
-      update.blue = parseInt(input.slice(4, 6), 16);
+      update = {
+        red: parseInt(input.slice(0, 2), 16),
+        green: parseInt(input.slice(2, 4), 16),
+        blue: parseInt(input.slice(4, 6), 16)
+      };
     }
   } else {
     // color(Byte, Byte, Byte)
-    update.red = red;
-    update.green = green;
-    update.blue = blue;
+    update = {
+      red: red,
+      green: green,
+      blue: blue
+    };
   }
 
-  Led.RGB.colors.forEach(function(color) {
+  // Validate all color values before writing any values
+  RGB.colors.forEach(function(color) {
     var value = update[color];
 
-    // == purposely checking null and undefined
     if (value == null) {
       throw new Error("Led.RGB.color: invalid color ([" + [update.red, update.green, update.blue].join(",") + "])");
     }
 
     // constrain to [0,255]
     value = Math.min(255, Math.max(0, value));
-
-    state[color] = value;
-    this[color].brightness(value);
+    update[color] = value;
   }, this);
+
+  this.write(update);
 
   return this;
 };
 
 RGB.prototype.on = function() {
   var state = priv.get(this);
+  var colors;
 
-  // If it's not already on, we turn
-  // them on to previous color value
+  // If it's not already on, we set them to the previous color
   if (!this.isOn) {
-    RGB.colors.forEach(function(color) {
-      this[color].brightness(state[color]);
-    }, this);
+    colors = state.prev || { red: 255, green: 255, blue: 255 };
+    delete state.prev;
+
+    this.write(colors);
   }
 
   return this;
 };
 
 RGB.prototype.off = function() {
-  RGB.colors.forEach(function(color) {
-    this[color].off();
-  }, this);
+  var state = priv.get(this);
+
+  // If it's already off, do nothing so the pervious state stays intact
+  if (this.isOn) {
+    state.prev = RGB.colors.reduce(function(current, color) {
+      return (current[color] = state[color], current);
+    }.bind(this), {});
+
+    this.write({ red: 0, green: 0, blue: 0 });
+  }
 
   return this;
 };
@@ -209,18 +323,12 @@ RGB.prototype.off = function() {
  * @return {Led}
  */
 RGB.prototype.strobe = function(rate) {
-  var state = priv.get(this);
-
   // Avoid traffic jams
   if (this.interval) {
     clearInterval(this.interval);
   }
 
-  state.isRunning = true;
-
-  this.interval = setInterval(function() {
-    this.toggle();
-  }.bind(this), rate || 100);
+  this.interval = setInterval(this.toggle.bind(this), rate || 100);
 
   return this;
 };
@@ -232,11 +340,8 @@ RGB.prototype.toggle = function() {
 };
 
 RGB.prototype.stop = function() {
-  var state = priv.get(this);
-
   clearInterval(this.interval);
-
-  state.isRunning = false;
+  delete this.interval;
 
   return this;
 };

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -38,8 +38,6 @@ var Controllers = {
 
           this.io.analogWrite(pin, value);
         }, this);
-
-        Object.assign(state, colors);
       }
     }
   },
@@ -102,8 +100,6 @@ var Controllers = {
 
           this.io.i2cWrite(this.address, [this.COMMANDS.LED0_ON_L + 4 * pin, on, on >> 8, off, off >> 8]);
         }, this);
-
-        Object.assign(state, colors);
       }
     }
   },
@@ -134,12 +130,8 @@ var Controllers = {
     write: {
       writable: true,
       value: function(colors) {
-        var state = priv.get(this);
-
         this.board.io.i2cWrite(this.address,
           [this.COMMANDS.GO_TO_RGB_COLOR_NOW, colors.red, colors.green, colors.blue]);
-
-        Object.assign(state, colors);
       }
     }
   }
@@ -232,6 +224,15 @@ var RGB = function(opts) {
         return RGB.colors.reduce(function(current, color) {
           return (current[color] = state[color], current);
         }, {});
+      }
+    },
+    writeColor: {
+      value: function(colors) {
+        var state = priv.get(this);
+
+        this.write(colors);
+
+        Object.assign(state, colors);
       }
     }
   });
@@ -330,7 +331,7 @@ RGB.prototype.color = function(red, green, blue) {
     update[color] = value;
   }, this);
 
-  this.write(update);
+  this.writeColor(update);
 
   return this;
 };
@@ -344,7 +345,7 @@ RGB.prototype.on = function() {
     colors = state.prev || { red: 255, green: 255, blue: 255 };
     delete state.prev;
 
-    this.write(colors);
+    this.writeColor(colors);
   }
 
   return this;
@@ -359,7 +360,7 @@ RGB.prototype.off = function() {
       return (current[color] = state[color], current);
     }.bind(this), {});
 
-    this.write({ red: 0, green: 0, blue: 0 });
+    this.writeColor({ red: 0, green: 0, blue: 0 });
   }
 
   return this;

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -24,6 +24,7 @@ var Controllers = {
       }
     },
     write: {
+      writable: true,
       value: function(colors) {
         var state = priv.get(this);
 
@@ -83,6 +84,7 @@ var Controllers = {
       }
     },
     write: {
+      writable: true,
       value: function(colors) {
         var state = priv.get(this);
 

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -149,14 +149,13 @@ var RGB = function(opts) {
 
   Object.defineProperties(this, controller);
 
-  this.interval = null;
-
   // The default color is #ffffff, but the light will be off
   state = {
     red: 255,
     green: 255,
     blue: 255,
-    isAnode: opts.isAnode || false
+    isAnode: opts.isAnode || false,
+    interval: null
   };
 
   priv.set(this, state);
@@ -171,7 +170,7 @@ var RGB = function(opts) {
     },
     isRunning: {
       get: function() {
-        return !!this.interval;
+        return !!state.interval;
       }
     },
     isAnode: {
@@ -323,12 +322,14 @@ RGB.prototype.off = function() {
  * @return {Led}
  */
 RGB.prototype.strobe = function(rate) {
+  var state = priv.get(this);
+
   // Avoid traffic jams
-  if (this.interval) {
-    clearInterval(this.interval);
+  if (state.interval) {
+    clearInterval(state.interval);
   }
 
-  this.interval = setInterval(this.toggle.bind(this), rate || 100);
+  state.interval = setInterval(this.toggle.bind(this), rate || 100);
 
   return this;
 };
@@ -340,8 +341,10 @@ RGB.prototype.toggle = function() {
 };
 
 RGB.prototype.stop = function() {
-  clearInterval(this.interval);
-  delete this.interval;
+  var state = priv.get(this);
+
+  clearInterval(state.interval);
+  delete state.interval;
 
   return this;
 };

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -121,7 +121,7 @@ var Controllers = {
           };
 
           // Stop the current script
-          this.board.io.i2cWrite(this.address, [this.COMMANDS.STOP_SCRIPT]);
+          this.io.i2cWrite(this.address, [this.COMMANDS.STOP_SCRIPT]);
 
           this.board.Drivers[this.address].initialized = true;
         }
@@ -130,7 +130,7 @@ var Controllers = {
     write: {
       writable: true,
       value: function(colors) {
-        this.board.io.i2cWrite(this.address,
+        this.io.i2cWrite(this.address,
           [this.COMMANDS.GO_TO_RGB_COLOR_NOW, colors.red, colors.green, colors.blue]);
       }
     }
@@ -226,7 +226,7 @@ var RGB = function(opts) {
         }, {});
       }
     },
-    writeColor: {
+    update: {
       value: function(colors) {
         var state = priv.get(this);
 
@@ -331,7 +331,7 @@ RGB.prototype.color = function(red, green, blue) {
     update[color] = value;
   }, this);
 
-  this.writeColor(update);
+  this.update(update);
 
   return this;
 };
@@ -345,7 +345,7 @@ RGB.prototype.on = function() {
     colors = state.prev || { red: 255, green: 255, blue: 255 };
     delete state.prev;
 
-    this.writeColor(colors);
+    this.update(colors);
   }
 
   return this;
@@ -360,7 +360,7 @@ RGB.prototype.off = function() {
       return (current[color] = state[color], current);
     }.bind(this), {});
 
-    this.writeColor({ red: 0, green: 0, blue: 0 });
+    this.update({ red: 0, green: 0, blue: 0 });
   }
 
   return this;

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -106,6 +106,42 @@ var Controllers = {
         Object.assign(state, colors);
       }
     }
+  },
+  BLINKM: {
+    COMMANDS: {
+      value: {
+        GO_TO_RGB_COLOR_NOW: 0x6e,
+        STOP_SCRIPT: 0x6f
+      }
+    },
+    initialize: {
+      value: function(opts) {
+        this.address = opts.address || 0x09;
+
+        if (!this.board.Drivers[this.address]) {
+          this.io.i2cConfig();
+          this.board.Drivers[this.address] = {
+            initialized: false
+          };
+
+          // Stop the current script
+          this.board.io.i2cWrite(this.address, [this.COMMANDS.STOP_SCRIPT]);
+
+          this.board.Drivers[this.address].initialized = true;
+        }
+      }
+    },
+    write: {
+      writable: true,
+      value: function(colors) {
+        var state = priv.get(this);
+
+        this.board.io.i2cWrite(this.address,
+          [this.COMMANDS.GO_TO_RGB_COLOR_NOW, colors.red, colors.green, colors.blue]);
+
+        Object.assign(state, colors);
+      }
+    }
   }
 };
 

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -145,6 +145,17 @@ var Controllers = {
   }
 };
 
+Controllers.ESPLORA = {
+  initialize: {
+    value: function(opts) {
+      opts.pins = [5, 10, 9];
+      this.pins = [];
+      Controllers.DEFAULT.initialize.value.call(this, opts);
+    }
+  },
+  write: Controllers.DEFAULT.write
+};
+
 /**
  * RGB
  * @constructor

--- a/test/led.js
+++ b/test/led.js
@@ -548,7 +548,7 @@ exports["Led.RGB"] = {
   params: function(test) {
     var led;
 
-    test.expect(3);
+    test.expect(5);
 
     // Test object constructor
     led = new Led.RGB({
@@ -569,6 +569,20 @@ exports["Led.RGB"] = {
     // Test array constructor
     led = new Led.RGB([9, 10, 11]);
     test.deepEqual(led.pins, [9, 10, 11]);
+
+    // Non-PWM digital pin
+    test.throws(function() {
+      new Led.RGB({
+        pins: [2, 3, 4]
+      });
+    }, /Pin Error: 2 is not a valid PWM pin \(Led\.RGB\)/);
+
+    // Analog pin
+    test.throws(function() {
+      new Led.RGB({
+        pins: ["A0", "A1", "A2"]
+      });
+    }, /Pin Error: \d+ is not a valid PWM pin \(Led\.RGB\)/);
 
     test.done();
   },

--- a/test/led.js
+++ b/test/led.js
@@ -546,6 +546,7 @@ exports["Led.RGB"] = {
     });
 
     this.analog = sinon.spy(this.board.io, "analogWrite");
+    this.write = sinon.spy(this.ledRgb, "write");
 
     done();
   },
@@ -592,56 +593,55 @@ exports["Led.RGB"] = {
     test.done();
   },
 
+  write: function(test) {
+    test.expect(4);
+
+    this.ledRgb.write({ red: 0xbb, green: 0xcc, blue: 0xaa });
+    test.ok(this.analog.callCount, 3);
+    test.ok(this.analog.calledWith(9, 0xbb));
+    test.ok(this.analog.calledWith(10, 0xcc));
+    test.ok(this.analog.calledWith(11, 0xaa));
+
+    test.done();
+  },
+
   color: function(test) {
-    var redPin = 9;
-    var greenPin = 10;
-    var bluePin = 11;
     var rgb = this.ledRgb;
 
-    test.expect(44);
+    test.expect(30);
 
     // returns this
     test.equal(this.ledRgb.color("#000000"), this.ledRgb);
-    this.analog.reset();
+    this.write.reset();
 
-    // Hex values
+    // hex values
     this.ledRgb.color("#0000ff");
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0x00));
-    test.ok(this.analog.calledWith(greenPin, 0x00));
-    test.ok(this.analog.calledWith(bluePin, 0xff));
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 0x00, green: 0x00, blue: 0xff }));
+    this.write.reset();
 
     this.ledRgb.color("#bbccaa");
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0xbb));
-    test.ok(this.analog.calledWith(greenPin, 0xcc));
-    test.ok(this.analog.calledWith(bluePin, 0xaa));
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 0xbb, green: 0xcc, blue: 0xaa }));
+    this.write.reset();
 
     // without "#"
     this.ledRgb.color("0000ff");
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0x00));
-    test.ok(this.analog.calledWith(greenPin, 0x00));
-    test.ok(this.analog.calledWith(bluePin, 0xff));
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 0x00, green: 0x00, blue: 0xff }));
+    this.write.reset();
 
     // three arguments
     this.ledRgb.color(255, 100, 50);
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 255));
-    test.ok(this.analog.calledWith(greenPin, 100));
-    test.ok(this.analog.calledWith(bluePin, 50));
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 255, green: 100, blue: 50 }));
+    this.write.reset();
 
     // with constraints
     this.ledRgb.color(999, -999, 0);
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 255));
-    test.ok(this.analog.calledWith(greenPin, 0));
-    test.ok(this.analog.calledWith(bluePin, 0));
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 255, green: 0, blue: 0 }));
+    this.write.reset();
 
     // by object
     this.ledRgb.color({
@@ -649,19 +649,15 @@ exports["Led.RGB"] = {
       green: 100,
       blue: 50
     });
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 255));
-    test.ok(this.analog.calledWith(greenPin, 100));
-    test.ok(this.analog.calledWith(bluePin, 50));
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 255, green: 100, blue: 50 }));
+    this.write.reset();
 
     // by array
     this.ledRgb.color([255, 100, 50]);
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 255));
-    test.ok(this.analog.calledWith(greenPin, 100));
-    test.ok(this.analog.calledWith(bluePin, 50));
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 255, green: 100, blue: 50 }));
+    this.write.reset();
 
     // bad values
     test.throws(function() {
@@ -727,11 +723,9 @@ exports["Led.RGB"] = {
   },
 
   on: function(test) {
-    var redPin = 9;
-    var greenPin = 10;
-    var bluePin = 11;
+    var color;
 
-    test.expect(22);
+    test.expect(23);
 
     test.ok(!this.ledRgb.isOn);
     test.deepEqual(this.ledRgb.values, {
@@ -739,25 +733,26 @@ exports["Led.RGB"] = {
     });
 
     // Should default to #ffffff
-    this.analog.reset();
+    this.write.reset();
     this.ledRgb.on();
 
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 255));
-    test.ok(this.analog.calledWith(greenPin, 255));
-    test.ok(this.analog.calledWith(bluePin, 255));
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 0xff, green: 0xff, blue: 0xff }));
+    this.write.reset();
 
-    var color = this.ledRgb.color();
+    color = this.ledRgb.color();
+    test.ok(!this.write.called);
     test.equal(color.red, 255);
     test.equal(color.green, 255);
     test.equal(color.blue, 255);
 
     // Set a color and make sure .on() doesn't override
     this.ledRgb.color("#bbccaa");
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 0xbb, green: 0xcc, blue: 0xaa }));
+    this.write.reset();
     this.ledRgb.on();
-    test.equal(this.analog.callCount, 0);
+    test.ok(!this.write.called);
 
     color = this.ledRgb.color();
     test.equal(color.red, 0xbb);
@@ -787,21 +782,15 @@ exports["Led.RGB"] = {
   },
 
   off: function(test) {
-    var redPin = 9;
-    var greenPin = 10;
-    var bluePin = 11;
-
-    test.expect(10);
+    test.expect(8);
 
     this.ledRgb.color("#bbccaa");
-    this.analog.reset();
+    this.write.reset();
 
     this.ledRgb.off();
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0));
-    test.ok(this.analog.calledWith(greenPin, 0));
-    test.ok(this.analog.calledWith(bluePin, 0));
-    this.analog.reset();
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 0, green: 0, blue: 0 }));
+    this.write.reset();
 
     // Test saved state
     var color = this.ledRgb.color();
@@ -830,43 +819,27 @@ exports["Led.RGB"] = {
   },
 
   toggle: function(test) {
-    var color;
-    var values;
+    test.expect(7);
 
-    test.expect(11);
+    var on = sinon.spy(this.ledRgb, "on");
+    var off = sinon.spy(this.ledRgb, "off");
 
-    // Sets color and turns it on
-    this.ledRgb.color("#bbccaa");
-
-    // toggle it off after setting color
-    this.ledRgb.toggle();
-
-    // test isOn property properly set
-    // after turning off
+    // Should default to off
     test.ok(!this.ledRgb.isOn);
 
-    // Color should still be #bbccaa
-    // but values should be 0
-    color = this.ledRgb.color();
-    test.equal(color.red, 0xbb);
-    test.equal(color.green, 0xcc);
-    test.equal(color.blue, 0xaa);
-
-    values = this.ledRgb.values;
-    test.equal(values.red, 0);
-    test.equal(values.green, 0);
-    test.equal(values.blue, 0);
-
-    // test isOn property properly set
-    // after turning back on
+    // Toggling should call on()
     this.ledRgb.toggle();
+    test.ok(on.calledOnce);
+    test.ok(!off.called);
     test.ok(this.ledRgb.isOn);
+    on.reset();
+    off.reset();
 
-    // Should have gone back to #bbccaa
-    values = this.ledRgb.values;
-    test.equal(values.red, 0xbb);
-    test.equal(values.green, 0xcc);
-    test.equal(values.blue, 0xaa);
+    // Toggling should call off()
+    this.ledRgb.toggle();
+    test.ok(off.calledOnce);
+    test.ok(!on.called);
+    test.ok(!this.ledRgb.isOn);
 
     test.done();
   },
@@ -905,270 +878,78 @@ exports["Led.RGB - Common Anode"] = {
     test.done();
   },
 
-  color: function(test) {
-    var redPin = 9;
-    var greenPin = 10;
-    var bluePin = 11;
-    var rgb = this.ledRgb;
+  write: function(test) {
+    test.expect(4);
 
-    test.expect(44);
+    this.ledRgb.write({ red: 0xbb, green: 0xcc, blue: 0xaa });
+    test.ok(this.analog.callCount, 3);
+    test.ok(this.analog.calledWith(9, 0x44));
+    test.ok(this.analog.calledWith(10, 0x33));
+    test.ok(this.analog.calledWith(11, 0x55));
 
-    // returns this
-    test.equal(this.ledRgb.color("#000000"), this.ledRgb);
-    this.analog.reset();
+    test.done();
+  }
+};
 
-    // Hex values
-    this.ledRgb.color("#0000ff");
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0xff));
-    test.ok(this.analog.calledWith(greenPin, 0xff));
-    test.ok(this.analog.calledWith(bluePin, 0x00));
-    this.analog.reset();
+exports["Led.RGB - PCA9685 (I2C)"] = {
+  setUp: function(done) {
+    this.board = newBoard();
 
-    this.ledRgb.color("#bbccaa");
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0x44));
-    test.ok(this.analog.calledWith(greenPin, 0x33));
-    test.ok(this.analog.calledWith(bluePin, 0x55));
-    this.analog.reset();
-
-    // without "#"
-    this.ledRgb.color("0000ff");
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0xff));
-    test.ok(this.analog.calledWith(greenPin, 0xff));
-    test.ok(this.analog.calledWith(bluePin, 0x00));
-    this.analog.reset();
-
-    // three arguments
-    this.ledRgb.color(255, 100, 50);
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0));
-    test.ok(this.analog.calledWith(greenPin, 155));
-    test.ok(this.analog.calledWith(bluePin, 205));
-    this.analog.reset();
-
-    // with constraints
-    this.ledRgb.color(999, -999, 0);
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0));
-    test.ok(this.analog.calledWith(greenPin, 255));
-    test.ok(this.analog.calledWith(bluePin, 255));
-    this.analog.reset();
-
-    // by object
-    this.ledRgb.color({
-      red: 255,
-      green: 100,
-      blue: 50
-    });
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0));
-    test.ok(this.analog.calledWith(greenPin, 155));
-    test.ok(this.analog.calledWith(bluePin, 205));
-    this.analog.reset();
-
-    // by array
-    this.ledRgb.color([255, 100, 50]);
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0));
-    test.ok(this.analog.calledWith(greenPin, 155));
-    test.ok(this.analog.calledWith(bluePin, 205));
-    this.analog.reset();
-
-    // bad values
-    test.throws(function() {
-      rgb.color(null);
+    this.ledRgb = new Led.RGB({
+      pins: {
+        red: 0,
+        green: 1,
+        blue: 2,
+      },
+      controller: "PCA9685",
+      board: this.board
     });
 
-    // shorthand not supported
-    test.throws(function() {
-      rgb.color("#fff");
-    });
+    this.i2cWrite = sinon.spy(this.board.io, "i2cWrite");
 
-    // bad hex
-    test.throws(function() {
-      rgb.color("#ggffff");
-    });
-    test.throws(function() {
-      rgb.color("#ggffffff");
-    });
-    test.throws(function() {
-      rgb.color("#ffffffff");
-    });
+    done();
+  },
 
-    // missing/null/undefined param
-    test.throws(function() {
-      rgb.color(10, 20);
-    });
-    test.throws(function() {
-      rgb.color(10, 20, null);
-    });
-    test.throws(function() {
-      rgb.color(10, undefined, 30);
-    });
+  shape: function(test) {
+    test.expect(rgbProtoProperties.length + rgbInstanceProperties.length);
 
-    // missing/null/undefined value in array
-    test.throws(function() {
-      rgb.color([10, 20]);
-    });
-    test.throws(function() {
-      rgb.color([10, null, 30]);
-    });
-    test.throws(function() {
-      rgb.color([10, undefined, 30]);
-    });
+    rgbProtoProperties.forEach(function(method) {
+      test.equal(typeof this.ledRgb[method.name], "function");
+    }, this);
 
-    // missing/null/undefined value in object
-    test.throws(function() {
-      rgb.color({red: 255, green: 100});
-    });
-    test.throws(function() {
-      rgb.color({red: 255, green: 100, blue: null});
-    });
-    test.throws(function() {
-      rgb.color({red: 255, green: 100, blue: undefined});
-    });
-
-    // returns color if no params
-    this.ledRgb.color([10, 20, 30]);
-    test.deepEqual(this.ledRgb.color(), {
-      red: 10, green: 20, blue: 30
-    });
+    rgbInstanceProperties.forEach(function(property) {
+      test.notEqual(typeof this.ledRgb[property.name], "undefined");
+    }, this);
 
     test.done();
   },
 
-  on: function(test) {
-    var redPin = 9;
-    var greenPin = 10;
-    var bluePin = 11;
+  write: function(test) {
+    test.expect(12);
 
-    test.expect(22);
+    // Fully off
+    this.ledRgb.write({ red: 0x00, green: 0x00, blue: 0x00 });
+    test.equal(this.i2cWrite.callCount, 3);
+    test.ok(this.i2cWrite.calledWith(64, [6, 0, 0, 0, 0]));
+    test.ok(this.i2cWrite.calledWith(64, [10, 0, 0, 0, 0]));
+    test.ok(this.i2cWrite.calledWith(64, [14, 0, 0, 0, 0]));
+    this.i2cWrite.reset();
 
-    test.ok(!this.ledRgb.isOn);
-    test.deepEqual(this.ledRgb.values, {
-      red: 0, green: 0, blue: 0
-    });
+    // Fully on
+    this.ledRgb.write({ red: 0xff, green: 0xff, blue: 0xff });
+    test.equal(this.i2cWrite.callCount, 3);
+    test.ok(this.i2cWrite.calledWith(64, [6, 0, 0, 4095, 15]));
+    test.ok(this.i2cWrite.calledWith(64, [10, 0, 0, 4095, 15]));
+    test.ok(this.i2cWrite.calledWith(64, [14, 0, 0, 4095, 15]));
+    this.i2cWrite.reset();
 
-    // Should default to #ffffff
-    this.analog.reset();
-    this.ledRgb.on();
-
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 0));
-    test.ok(this.analog.calledWith(greenPin, 0));
-    test.ok(this.analog.calledWith(bluePin, 0));
-    this.analog.reset();
-
-    var color = this.ledRgb.color();
-    test.equal(color.red, 255);
-    test.equal(color.green, 255);
-    test.equal(color.blue, 255);
-
-    // Set a color and make sure .on() doesn't override
-    this.ledRgb.color("#bbccaa");
-    this.analog.reset();
-    this.ledRgb.on();
-    test.equal(this.analog.callCount, 0);
-
-    color = this.ledRgb.color();
-    test.equal(color.red, 0xbb);
-    test.equal(color.green, 0xcc);
-    test.equal(color.blue, 0xaa);
-
-    // And that those values are actually live
-    var values = this.ledRgb.values;
-    test.equal(values.red, 0xbb);
-    test.equal(values.green, 0xcc);
-    test.equal(values.blue, 0xaa);
-
-    // Turn led off and back on to see if state restored
-    this.ledRgb.off();
-    this.ledRgb.on();
-    color = this.ledRgb.color();
-    test.equal(color.red, 0xbb);
-    test.equal(color.green, 0xcc);
-    test.equal(color.blue, 0xaa);
-
-    values = this.ledRgb.values;
-    test.equal(values.red, 0xbb);
-    test.equal(values.green, 0xcc);
-    test.equal(values.blue, 0xaa);
-
-    test.done();
-  },
-
-  off: function(test) {
-    var redPin = 9;
-    var greenPin = 10;
-    var bluePin = 11;
-
-    test.expect(10);
-
-    this.ledRgb.color("#bbccaa");
-    this.analog.reset();
-
-    this.ledRgb.off();
-    test.equal(this.analog.callCount, 3);
-    test.ok(this.analog.calledWith(redPin, 255));
-    test.ok(this.analog.calledWith(greenPin, 255));
-    test.ok(this.analog.calledWith(bluePin, 255));
-    this.analog.reset();
-
-    // Test saved state
-    var color = this.ledRgb.color();
-    test.equal(color.red, 0xbb);
-    test.equal(color.green, 0xcc);
-    test.equal(color.blue, 0xaa);
-
-    // Test live values
-    var values = this.ledRgb.values;
-    test.equal(values.red, 0);
-    test.equal(values.green, 0);
-    test.equal(values.blue, 0);
-
-    test.done();
-  },
-
-  toggle: function(test) {
-    var color;
-    var values;
-
-    test.expect(11);
-
-    // Sets color and turns it on
-    this.ledRgb.color("#bbccaa");
-
-    // toggle it off after setting color
-    this.ledRgb.toggle();
-
-    // test isOn property properly set
-    // after turning off
-    test.ok(!this.ledRgb.isOn);
-
-    // Color should still be #bbccaa
-    // but values should be 0
-    color = this.ledRgb.color();
-    test.equal(color.red, 0xbb);
-    test.equal(color.green, 0xcc);
-    test.equal(color.blue, 0xaa);
-
-    values = this.ledRgb.values;
-    test.equal(values.red, 0);
-    test.equal(values.green, 0);
-    test.equal(values.blue, 0);
-
-    // test isOn property properly set
-    // after turning back on
-    this.ledRgb.toggle();
-    test.ok(this.ledRgb.isOn);
-
-    // Should have gone back to #bbccaa
-    values = this.ledRgb.values;
-    test.equal(values.red, 0xbb);
-    test.equal(values.green, 0xcc);
-    test.equal(values.blue, 0xaa);
+    // Custom color
+    this.ledRgb.write({ red: 0xbb, green: 0xcc, blue: 0xaa });
+    test.equal(this.i2cWrite.callCount, 3);
+    test.ok(this.i2cWrite.calledWith(64, [6, 0, 0, 3003, 11]));
+    test.ok(this.i2cWrite.calledWith(64, [10, 0, 0, 3276, 12]));
+    test.ok(this.i2cWrite.calledWith(64, [14, 0, 0, 2730, 10]));
+    this.i2cWrite.reset();
 
     test.done();
   }

--- a/test/led.js
+++ b/test/led.js
@@ -955,6 +955,59 @@ exports["Led.RGB - PCA9685 (I2C)"] = {
   }
 };
 
+exports["Led.RGB - BlinkM (I2C)"] = {
+  setUp: function(done) {
+    this.board = newBoard();
+
+    this.ledRgb = new Led.RGB({
+      controller: "BlinkM",
+      board: this.board
+    });
+
+    this.i2cWrite = sinon.spy(this.board.io, "i2cWrite");
+
+    done();
+  },
+
+  shape: function(test) {
+    test.expect(rgbProtoProperties.length + rgbInstanceProperties.length);
+
+    rgbProtoProperties.forEach(function(method) {
+      test.equal(typeof this.ledRgb[method.name], "function");
+    }, this);
+
+    rgbInstanceProperties.forEach(function(property) {
+      test.notEqual(typeof this.ledRgb[property.name], "undefined");
+    }, this);
+
+    test.done();
+  },
+
+  write: function(test) {
+    test.expect(6);
+
+    // Fully off
+    this.ledRgb.write({ red: 0x00, green: 0x00, blue: 0x00 });
+    test.equal(this.i2cWrite.callCount, 1);
+    test.ok(this.i2cWrite.calledWith(0x09, [0x6e, 0x00, 0x00, 0x00]));
+    this.i2cWrite.reset();
+
+    // Fully on
+    this.ledRgb.write({ red: 0xff, green: 0xff, blue: 0xff });
+    test.equal(this.i2cWrite.callCount, 1);
+    test.ok(this.i2cWrite.calledWith(0x09, [0x6e, 0xff, 0xff, 0xff]));
+    this.i2cWrite.reset();
+
+    // Custom color
+    this.ledRgb.write({ red: 0xbb, green: 0xcc, blue: 0xaa });
+    test.equal(this.i2cWrite.callCount, 1);
+    test.ok(this.i2cWrite.calledWith(0x09, [0x6e, 0xbb, 0xcc, 0xaa]));
+    this.i2cWrite.reset();
+
+    test.done();
+  }
+};
+
 exports["Led - Default Pin w/ Firmata"] = {
   shape: function(test) {
     test.expect(8);

--- a/test/led.js
+++ b/test/led.js
@@ -34,8 +34,6 @@ var instanceProperties = [{
   name: "pin"
 }, {
   name: "value"
-}, {
-  name: "interval"
 }];
 
 var rgbProtoProperties = [{
@@ -54,9 +52,7 @@ var rgbProtoProperties = [{
   name: "stop"
 }];
 
-var rgbInstanceProperties = [{
-  name: "interval"
-}];
+var rgbInstanceProperties = [];
 
 function newBoard() {
   var io = new MockFirmata();

--- a/test/led.js
+++ b/test/led.js
@@ -978,6 +978,61 @@ exports["Led.RGB - BlinkM (I2C)"] = {
   }
 };
 
+exports["Led.RGB - Esplora"] = {
+  setUp: function(done) {
+    this.board = newBoard();
+
+    this.ledRgb = new Led.RGB({
+      controller: "Esplora",
+      board: this.board
+    });
+
+    this.analog = sinon.spy(this.board.io, "analogWrite");
+
+    done();
+  },
+
+  shape: testLedRgbShape,
+
+  initialization: function(test) {
+    test.expect(1);
+
+    test.deepEqual(this.ledRgb.pins, [5, 10, 9]);
+
+    test.done();
+  },
+
+  write: function(test) {
+    test.expect(12);
+
+    // Fully off
+    this.ledRgb.write({ red: 0x00, green: 0x00, blue: 0x00 });
+    test.ok(this.analog.callCount, 3);
+    test.ok(this.analog.calledWith(5, 0x00));
+    test.ok(this.analog.calledWith(10, 0x00));
+    test.ok(this.analog.calledWith(9, 0x00));
+    this.analog.reset();
+
+    // Fully on
+    this.ledRgb.write({ red: 0xff, green: 0xff, blue: 0xff });
+    test.ok(this.analog.callCount, 3);
+    test.ok(this.analog.calledWith(5, 0xff));
+    test.ok(this.analog.calledWith(10, 0xff));
+    test.ok(this.analog.calledWith(9, 0xff));
+    this.analog.reset();
+
+    // Custom color
+    this.ledRgb.write({ red: 0xbb, green: 0xcc, blue: 0xaa });
+    test.ok(this.analog.callCount, 3);
+    test.ok(this.analog.calledWith(5, 0xbb));
+    test.ok(this.analog.calledWith(10, 0xcc));
+    test.ok(this.analog.calledWith(9, 0xaa));
+    this.analog.reset();
+
+    test.done();
+  }
+};
+
 exports["Led - Default Pin w/ Firmata"] = {
   shape: function(test) {
     test.expect(8);

--- a/test/led.js
+++ b/test/led.js
@@ -67,6 +67,34 @@ function newBoard() {
   return board;
 }
 
+function testLedShape(test) {
+  test.expect(protoProperties.length + instanceProperties.length);
+
+  protoProperties.forEach(function(method) {
+    test.equal(typeof this.led[method.name], "function");
+  }, this);
+
+  instanceProperties.forEach(function(property) {
+    test.notEqual(typeof this.led[property.name], "undefined");
+  }, this);
+
+  test.done();
+}
+
+function testLedRgbShape(test) {
+  test.expect(rgbProtoProperties.length + rgbInstanceProperties.length);
+
+  rgbProtoProperties.forEach(function(method) {
+    test.equal(typeof this.ledRgb[method.name], "function");
+  }, this);
+
+  rgbInstanceProperties.forEach(function(property) {
+    test.notEqual(typeof this.ledRgb[property.name], "undefined");
+  }, this);
+
+  test.done();
+}
+
 exports["Led - Digital"] = {
   setUp: function(done) {
     this.board = newBoard();
@@ -87,19 +115,7 @@ exports["Led - Digital"] = {
     done();
   },
 
-  shape: function(test) {
-    test.expect(protoProperties.length + instanceProperties.length);
-
-    protoProperties.forEach(function(method) {
-      test.equal(typeof this.led[method.name], "function");
-    }, this);
-
-    instanceProperties.forEach(function(property) {
-      test.notEqual(typeof this.led[property.name], "undefined");
-    }, this);
-
-    test.done();
-  },
+  shape: testLedShape,
 
   pinMode: function(test) {
     test.expect(2);
@@ -260,19 +276,7 @@ exports["Led - PWM (Analog)"] = {
     done();
   },
 
-  shape: function(test) {
-    test.expect(protoProperties.length + instanceProperties.length);
-
-    protoProperties.forEach(function(method) {
-      test.equal(typeof this.led[method.name], "function");
-    }, this);
-
-    instanceProperties.forEach(function(property) {
-      test.notEqual(typeof this.led[property.name], "undefined");
-    }, this);
-
-    test.done();
-  },
+  shape: testLedShape,
 
   pinMode: function(test) {
     test.expect(2);
@@ -368,19 +372,7 @@ exports["Led - PCA9685 (I2C)"] = {
     done();
   },
 
-  shape: function(test) {
-    test.expect(protoProperties.length + instanceProperties.length);
-
-    protoProperties.forEach(function(method) {
-      test.equal(typeof this.led[method.name], "function");
-    }, this);
-
-    instanceProperties.forEach(function(property) {
-      test.notEqual(typeof this.led[property.name], "undefined");
-    }, this);
-
-    test.done();
-  },
+  shape: testLedShape,
 
   defaultMode: function(test) {
     test.expect(2);
@@ -551,19 +543,7 @@ exports["Led.RGB"] = {
     done();
   },
 
-  shape: function(test) {
-    test.expect(rgbProtoProperties.length + rgbInstanceProperties.length);
-
-    rgbProtoProperties.forEach(function(method) {
-      test.equal(typeof this.ledRgb[method.name], "function");
-    }, this);
-
-    rgbInstanceProperties.forEach(function(property) {
-      test.notEqual(typeof this.ledRgb[property.name], "undefined");
-    }, this);
-
-    test.done();
-  },
+  shape: testLedRgbShape,
 
   params: function(test) {
     var led;
@@ -910,19 +890,7 @@ exports["Led.RGB - PCA9685 (I2C)"] = {
     done();
   },
 
-  shape: function(test) {
-    test.expect(rgbProtoProperties.length + rgbInstanceProperties.length);
-
-    rgbProtoProperties.forEach(function(method) {
-      test.equal(typeof this.ledRgb[method.name], "function");
-    }, this);
-
-    rgbInstanceProperties.forEach(function(property) {
-      test.notEqual(typeof this.ledRgb[property.name], "undefined");
-    }, this);
-
-    test.done();
-  },
+  shape: testLedRgbShape,
 
   write: function(test) {
     test.expect(12);
@@ -969,19 +937,7 @@ exports["Led.RGB - BlinkM (I2C)"] = {
     done();
   },
 
-  shape: function(test) {
-    test.expect(rgbProtoProperties.length + rgbInstanceProperties.length);
-
-    rgbProtoProperties.forEach(function(method) {
-      test.equal(typeof this.ledRgb[method.name], "function");
-    }, this);
-
-    rgbInstanceProperties.forEach(function(property) {
-      test.notEqual(typeof this.ledRgb[property.name], "undefined");
-    }, this);
-
-    test.done();
-  },
+  shape: testLedRgbShape,
 
   write: function(test) {
     test.expect(6);


### PR DESCRIPTION
Ref #742 

The initial work is done. `Led.RGB` now uses the device/controller model and has full support for direct use and PCA9685. I'll be adding support for BlinkM and Esplora controllers as well. Since the majority of the work is already done, I figured I'd file the PR now to start getting feedback.