### PR TITLE
Led.RGB: Add intensity method

### DIFF
--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -269,7 +269,7 @@ RGB.prototype.color = function(red, green, blue) {
     // not a reference to the state object itself.
     colors = this.isOn ? state : state.prev;
     return RGB.colors.reduce(function(current, color) {
-      return (current[color] = colors[color], current);
+      return (current[color] = Math.round(colors[color]), current);
     }, {});
   }
 
@@ -401,6 +401,39 @@ RGB.prototype.stop = function() {
 
   clearInterval(state.interval);
   delete state.interval;
+
+  return this;
+};
+
+RGB.prototype.intensity = function(intensity) {
+  var state = priv.get(this);
+  var colors = this.isOn ? state : state.prev;
+
+  // Calculate current intensity on a scale of 0-1
+  var currentIntensity = RGB.colors.reduce(function(current, color) {
+    return Math.max(colors[color], current);
+  }, 0) / 255;
+
+  if (arguments.length === 0) {
+    return Math.round(currentIntensity * 100);
+  }
+
+  var scale = 1 / currentIntensity * Math.min(100, Math.max(0, intensity)) / 100;
+  var scaledColors = RGB.colors.reduce(function(current, color) {
+    return (current[color] = colors[color] * scale, current);
+  }, {});
+
+  // If the intensity is low enough to turn off all three colors,
+  // go through .off() to store the current color
+  var turningOff = RGB.colors.reduce(function(current, color) {
+    return current && (Math.round(scaledColors[color]) === 0);
+  }, true);
+
+  if (turningOff) {
+    this.off();
+  } else {
+    this.update(scaledColors);
+  }
 
   return this;
 };

--- a/test/led.js
+++ b/test/led.js
@@ -842,6 +842,37 @@ exports["Led.RGB"] = {
     test.expect(1);
     test.equal(this.ledRgb.blink, this.ledRgb.strobe);
     test.done();
+  },
+
+  intensity: function(test) {
+    test.expect(13);
+
+    this.ledRgb.color("#33aa00");
+    test.equal(this.ledRgb.intensity(), 67);
+    this.write.reset();
+
+    // full intensity
+    test.equal(this.ledRgb.intensity(100), this.ledRgb);
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 76.5, green: 255, blue: 0 }));
+    test.ok(this.ledRgb.intensity(), 100);
+    this.write.reset();
+
+    // fully off
+    test.equal(this.ledRgb.intensity(0), this.ledRgb);
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 0, green: 0, blue: 0 }));
+    test.ok(this.ledRgb.intensity(), 0);
+    this.write.reset();
+
+    // restore from off
+    test.equal(this.ledRgb.intensity(50), this.ledRgb);
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 38.25, green: 127.5, blue: 0 }));
+    test.ok(this.ledRgb.intensity(), 50);
+    this.write.reset();
+
+    test.done();
   }
 };
 


### PR DESCRIPTION
Fixes #737

I want to make sure this is the expected functionality before I write the tests for this.

The idea is that we find the color with the highest value and scale based on that. The internal values may contain fractional values as a result, but this ensures that we're not losing information as we scale to very low intensities. As a result, `.color()` when used as a getter has been modified to round the values. This currently works fine, but I'm not sure if we should be rounding the values before sending them to `io` just to be safe.