### PR TITLE
Updated the tinkerkit examples with working website.

### DIFF
--- a/docs/tinkerkit-accelerometer.md
+++ b/docs/tinkerkit-accelerometer.md
@@ -29,7 +29,7 @@ board.on("ready", function() {
   //
   // Devices:
   //
-  // - Dual Axis http://www.tinkerkit.com/accelerometer/
+  // - Dual Axis http://tinkerkit.tihhs.nl/accelerometer/
   //
 
   accel = new five.Accelerometer({

--- a/docs/tinkerkit-blink.md
+++ b/docs/tinkerkit-blink.md
@@ -43,8 +43,8 @@ new five.Board().on("ready", function() {
 
 
 ## Additional Notes
-- [TinkerKit Led](http://www.tinkerkit.com/led-red-10mm/)
-- [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+- [TinkerKit Led](http://tinkerkit.tihhs.nl/led-red-10mm/)
+- [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 
 &nbsp;
 

--- a/docs/tinkerkit-button.md
+++ b/docs/tinkerkit-button.md
@@ -52,8 +52,8 @@ new five.Board().on("ready", function() {
 
 
 ## Additional Notes
-- [TinkerKit Button](http://www.tinkerkit.com/button/)
-- [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+- [TinkerKit Button](http://tinkerkit.tihhs.nl/button/)
+- [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 
 &nbsp;
 

--- a/docs/tinkerkit-continuous-servo.md
+++ b/docs/tinkerkit-continuous-servo.md
@@ -50,9 +50,9 @@ new five.Board().on("ready", function() {
 
 
 ## Additional Notes
-- [TinkerKit Servo](http://www.tinkerkit.com/servo/)
-- [TinkerKit Linear Potentiometer](http://www.tinkerkit.com/linear-pot/)
-- [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+- [TinkerKit Servo](http://tinkerkit.tihhs.nl/servo/)
+- [TinkerKit Linear Potentiometer](http://tinkerkit.tihhs.nl/linear-pot/)
+- [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 
 &nbsp;
 

--- a/docs/tinkerkit-joystick.md
+++ b/docs/tinkerkit-joystick.md
@@ -76,8 +76,8 @@ new five.Board().on("ready", function() {
 
 
 ## Additional Notes
-- [TinkerKit JoyStick](http://www.tinkerkit.com/joystick/)
-- [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+- [TinkerKit JoyStick](http://tinkerkit.tihhs.nl/joystick/)
+- [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 
 &nbsp;
 

--- a/docs/tinkerkit-linear-pot.md
+++ b/docs/tinkerkit-linear-pot.md
@@ -45,9 +45,8 @@ new five.Board().on("ready", function() {
 
 
 ## Additional Notes
-- [TinkerKit Linear Potentiometer](http://www.tinkerkit.com/linear-pot/)
-- [TinkerKit Led](http://www.tinkerkit.com/led/)
-- [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+- [TinkerKit Linear Potentiometer](http://tinkerkit.tihhs.nl/linear-pot/)
+- [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 
 &nbsp;
 

--- a/docs/tinkerkit-rotary.md
+++ b/docs/tinkerkit-rotary.md
@@ -47,9 +47,9 @@ new five.Board().on("ready", function() {
 
 
 ## Additional Notes
-- [TinkerKit Servo](http://www.tinkerkit.com/servo/)
-- [TinkerKit Linear Potentiometer](http://www.tinkerkit.com/linear-pot/)
-- [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+- [TinkerKit Servo](http://tinkerkit.tihhs.nl/servo/)
+- [TinkerKit Linear Potentiometer](http://tinkerkit.tihhs.nl/linear-pot/)
+- [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 
 &nbsp;
 

--- a/docs/tinkerkit-thermistor.md
+++ b/docs/tinkerkit-thermistor.md
@@ -46,8 +46,8 @@ new five.Board().on("ready", function() {
 
 
 ## Additional Notes
-- [TinkerKit Thermistor](http://www.tinkerkit.com/thermistor/)
-- [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+- [TinkerKit Thermistor](http://tinkerkit.tihhs.nl/thermistor/)
+- [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 
 &nbsp;
 

--- a/docs/tinkerkit-tilt.md
+++ b/docs/tinkerkit-tilt.md
@@ -47,9 +47,9 @@ new five.Board().on("ready", function() {
 
 
 ## Additional Notes
-- [TinkerKit Servo](http://www.tinkerkit.com/servo/)
-- [TinkerKit Linear Potentiometer](http://www.tinkerkit.com/linear-pot/)
-- [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+- [TinkerKit Servo](http://tinkerkit.tihhs.nl/servo/)
+- [TinkerKit Linear Potentiometer](http://tinkerkit.tihhs.nl/linear-pot/)
+- [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 
 &nbsp;
 

--- a/docs/tinkerkit-touch.md
+++ b/docs/tinkerkit-touch.md
@@ -55,8 +55,8 @@ new five.Board().on("ready", function() {
 
 
 ## Additional Notes
-- [TinkerKit Touch](http://www.tinkerkit.com/touch/)
-- [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+- [TinkerKit Touch](http://tinkerkit.tihhs.nl/touch/)
+- [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 
 &nbsp;
 

--- a/eg/tinkerkit-accelerometer.js
+++ b/eg/tinkerkit-accelerometer.js
@@ -9,7 +9,7 @@ board.on("ready", function() {
   //
   // Devices:
   //
-  // - Dual Axis http://www.tinkerkit.com/accelerometer/
+  // - Dual Axis http://tinkerkit.tihhs.nl/accelerometer/
   //
 
   accel = new five.Accelerometer({

--- a/eg/tinkerkit-blink.js
+++ b/eg/tinkerkit-blink.js
@@ -5,6 +5,6 @@ new five.Board().on("ready", function() {
 });
 
 // @markdown
-// - [TinkerKit Led](http://www.tinkerkit.com/led-red-10mm/)
-// - [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+// - [TinkerKit Led](http://tinkerkit.tihhs.nl/led-red-10mm/)
+// - [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 // @markdown

--- a/eg/tinkerkit-button.js
+++ b/eg/tinkerkit-button.js
@@ -14,6 +14,6 @@ new five.Board().on("ready", function() {
 });
 
 // @markdown
-// - [TinkerKit Button](http://www.tinkerkit.com/button/)
-// - [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+// - [TinkerKit Button](http://tinkerkit.tihhs.nl/button/)
+// - [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 // @markdown

--- a/eg/tinkerkit-continuous-servo.js
+++ b/eg/tinkerkit-continuous-servo.js
@@ -12,7 +12,7 @@ new five.Board().on("ready", function() {
 });
 
 // @markdown
-// - [TinkerKit Servo](http://www.tinkerkit.com/servo/)
-// - [TinkerKit Linear Potentiometer](http://www.tinkerkit.com/linear-pot/)
-// - [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+// - [TinkerKit Servo](http://tinkerkit.tihhs.nl/servo/)
+// - [TinkerKit Linear Potentiometer](http://tinkerkit.tihhs.nl/linear-pot/)
+// - [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 // @markdown

--- a/eg/tinkerkit-joystick.js
+++ b/eg/tinkerkit-joystick.js
@@ -46,6 +46,6 @@ new five.Board().on("ready", function() {
 });
 
 // @markdown
-// - [TinkerKit JoyStick](http://www.tinkerkit.com/joystick/)
-// - [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+// - [TinkerKit JoyStick](http://tinkerkit.tihhs.nl/joystick/)
+// - [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 // @markdown

--- a/eg/tinkerkit-linear-pot.js
+++ b/eg/tinkerkit-linear-pot.js
@@ -7,7 +7,6 @@ new five.Board().on("ready", function() {
 });
 
 // @markdown
-// - [TinkerKit Linear Potentiometer](http://www.tinkerkit.com/linear-pot/)
-// - [TinkerKit Led](http://www.tinkerkit.com/led/)
-// - [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+// - [TinkerKit Linear Potentiometer](http://tinkerkit.tihhs.nl/linear-pot/)
+// - [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 // @markdown

--- a/eg/tinkerkit-rotary.js
+++ b/eg/tinkerkit-rotary.js
@@ -9,7 +9,7 @@ new five.Board().on("ready", function() {
 });
 
 // @markdown
-// - [TinkerKit Servo](http://www.tinkerkit.com/servo/)
-// - [TinkerKit Linear Potentiometer](http://www.tinkerkit.com/linear-pot/)
-// - [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+// - [TinkerKit Servo](http://tinkerkit.tihhs.nl/servo/)
+// - [TinkerKit Linear Potentiometer](http://tinkerkit.tihhs.nl/linear-pot/)
+// - [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 // @markdown

--- a/eg/tinkerkit-thermistor.js
+++ b/eg/tinkerkit-thermistor.js
@@ -8,6 +8,6 @@ new five.Board().on("ready", function() {
 });
 
 // @markdown
-// - [TinkerKit Thermistor](http://www.tinkerkit.com/thermistor/)
-// - [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+// - [TinkerKit Thermistor](http://tinkerkit.tihhs.nl/thermistor/)
+// - [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 // @markdown

--- a/eg/tinkerkit-tilt.js
+++ b/eg/tinkerkit-tilt.js
@@ -9,7 +9,7 @@ new five.Board().on("ready", function() {
 });
 
 // @markdown
-// - [TinkerKit Servo](http://www.tinkerkit.com/servo/)
-// - [TinkerKit Linear Potentiometer](http://www.tinkerkit.com/linear-pot/)
-// - [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+// - [TinkerKit Servo](http://tinkerkit.tihhs.nl/servo/)
+// - [TinkerKit Linear Potentiometer](http://tinkerkit.tihhs.nl/linear-pot/)
+// - [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 // @markdown

--- a/eg/tinkerkit-touch.js
+++ b/eg/tinkerkit-touch.js
@@ -17,6 +17,6 @@ new five.Board().on("ready", function() {
 });
 
 // @markdown
-// - [TinkerKit Touch](http://www.tinkerkit.com/touch/)
-// - [TinkerKit Shield](http://www.tinkerkit.com/shield/)
+// - [TinkerKit Touch](http://tinkerkit.tihhs.nl/touch/)
+// - [TinkerKit Shield](http://tinkerkit.tihhs.nl/shield/)
 // @markdown


### PR DESCRIPTION
The TinkerKit examples have links to the parts needed for the examples.  The http://www.tinkerkit.com website went dark around mid-2014 it looks like.

I updated to the http://tinkerkit.tihhs.nl/ domain and all of the examples now link appropriately.