### PR TITLE
Interval is no longer a property on LED's

### DIFF
--- a/test/extended/led.js
+++ b/test/extended/led.js
@@ -53,8 +53,6 @@ exports["Led - PWM (Analog)"] = {
       name: "pin"
     }, {
       name: "value"
-    }, {
-      name: "interval"
     }];
 
     done();


### PR DESCRIPTION
Was causing extended tests to fail.