### PR TITLE
Update broken and outdated links for parts.md

### DIFF
--- a/parts.md
+++ b/parts.md
@@ -1,7 +1,7 @@
 # Easy "Getting Started"
 
-- [Sparkfun Inventor's Kit](https://www.sparkfun.com/products/11022)
-
+- KIT-11576 [Sparkfun Inventor's Kit](https://www.sparkfun.com/products/12060) replaces [RTL-11236](https://www.sparkfun.com/products/retired/11236)
+  * Follow the _Replaces_ link shown after the documents links for RTL-11236 for even older retired versions -- for references to software and documentation that may have changed in the later versions
 
 # Parts
 
@@ -9,7 +9,7 @@
 ## Adafruit
 
 - [Triple-Axis Accelerometer, ADXL326](http://www.adafruit.com/products/1018)
-- [Motor Shield](http://www.adafruit.com/products/81)
+- [Motor Shield](http://www.adafruit.com/products/1438)
 - [MaxSonar](https://www.adafruit.com/products/172)
 - [Bumper Switch](https://www.adafruit.com/products/818)
 
@@ -18,7 +18,7 @@
 
 - [Futuba Servo](http://www.amazon.com/Futaba-S3003-Servo-Standard/dp/B0015H2V72/ref=sr_1_1?s=toys-and-games&ie=UTF8&qid=1345046435&sr=1-1&keywords=futaba+servo)
 - [Hitec HS322HD Servo](http://www.amazon.com/Hitec-33322S-HS-322HD-Standard-Karbonite/dp/B0006O3XEA/ref=sr_1_cc_2?s=aps&ie=UTF8&qid=1345046396&sr=1-2-catcorr&keywords=hitec+servo)
-- [OSEPP I2C Expansion Shield](http://www.amazon.com/OSEPP-Expansion-Schield-Arduino-Compatible/dp/B007JBUL0C/ref=sr_1_10?s=electronics&ie=UTF8&qid=1345046344&sr=1-10&keywords=i2c+shield)
+- [OSEPP I2C Expansion Shield](http://www.amazon.com/OSEPP-I2CSHD-01-I2C-Expansion-Shield/dp/B008MOOEA8/ref=sr_1_1?ie=UTF8&qid=1435807356&sr=8-1&keywords=OSEPP+I2C+Expansion+Shield+Arduino+Compatible)
 - [SainSmart Sensor Shield](http://www.amazon.com/SainSmart-Sensor-Digital-Arduino-Duemilanove/dp/B006TQ314G)
 
 
@@ -41,27 +41,28 @@
 
 ## Parallax
 
-- **[Robot Base](http://www.parallax.com/Store/Education/KitsandBoards/tabid/182/ProductID/820/List/0/Default.aspx?SortField=ProductName,ProductName)**
-- [2 Axis Joystick](http://www.parallax.com/Store/Sensors/PressureFlexRPM/tabid/177/ProductID/581/List/0/Default.aspx?SortField=ProductName,ProductName)
-- [5 Position Switch](http://www.parallax.com/Store/Sensors/PressureFlexRPM/tabid/177/ProductID/615/List/0/Default.aspx?SortField=ProductName,ProductName)
-- [Gripper Kit](http://www.parallax.com/StoreSearchResults/tabid/768/txtSearch/clamp/List/0/SortField/4/ProductID/311/Default.aspx)
-- [PMB-648 GPS SiRF Internal Antenna](http://www.parallax.com/Store/Microcontrollers/BASICStampModules/tabid/134/txtSearch/gps/List/1/ProductID/644/Default.aspx?SortField=ProductName%2cProductName)
-- [Ping)))](http://www.parallax.com/Store/Sensors/ObjectDetection/tabid/176/ProductID/92/List/0/Default.aspx?SortField=ProductName,ProductName)
-- [PIR](http://www.parallax.com/Store/Sensors/ObjectDetection/tabid/176/ProductID/83/List/0/Default.aspx?SortField=ProductName,ProductName)
-- [Standard Servo](http://www.parallax.com/Store/Accessories/MotorServos/tabid/163/ProductID/101/List/0/Default.aspx?SortField=ProductName,ProductName)
-- [Continuous Servo](http://www.parallax.com/Store/Robots/RoboticComponents/tabid/198/List/0/ProductID/102/Default.aspx?SortField=ProductName%2cProductName)
-- [Tank Tread Kit](http://www.parallax.com/Store/Robots/RoboticAccessories/tabid/145/ProductID/78/List/0/Default.aspx?SortField=ProductName,ProductName)
+- [Robot Bases](https://www.parallax.com/catalog/robotics/complete-robots)
+- [2 Axis Joystick](https://www.parallax.com/product/27800)
+- [5 Position Switch](https://www.parallax.com/product/27801)
+- [Gripper Kit](https://www.parallax.com/product/28202)
+- [PMB-648 GPS SiRF Internal Antenna](https://www.parallax.com/product/28501)
+- [Ping))) Ultrasonic Distance Sensor](https://www.parallax.com/product/28015)
+- [PIR Sensors](https://www.parallax.com/search?search_api_views_fulltext=pir+sensor)
+- [Standard Servo](https://www.parallax.com/product/900-00005)
+- [Continuous Servo](https://www.parallax.com/product/900-00008)
+- [Tank Tread Kit](https://www.parallax.com/product/28106)
 
 
 ## Sparkfun
 
 
-- [Triple Axis Accelerometer, MMA7361](https://www.sparkfun.com/products/9652)
+- [Triple Axis Accelerometer, ADXL345](https://www.sparkfun.com/products/9836)
 - [Arcade Joystick](http://www.sparkfun.com/products/9136)
-- [Laser Card Module - Red](http://www.sparkfun.com/products/594)
+- retired [Laser Card Module - Red](http://www.sparkfun.com/products/594)
+- [Laser Module - Green](https://www.sparkfun.com/products/9906)
 - [Pan/Tilt Bracket](http://www.sparkfun.com/products/10335)
 - [Robotic Claw](http://www.sparkfun.com/products/10332)
-- [Robotic Claw Pan/Tilt Bracket](http://www.sparkfun.com/products/10826)
+- replaced and retired [Robotic Claw Pan/Tilt Bracket](http://www.sparkfun.com/products/10826)
 - [Servo Extension Cable - Female to Female (shrouded)](http://www.sparkfun.com/products/8738)
 - [Servo Cable - Female to Female](http://www.sparkfun.com/products/9187)
 - [Servo - Medium](http://www.sparkfun.com/products/10333)


### PR DESCRIPTION
I was browsing through parts.md, and found a lot of broken, replaced, and retired links.  I updated things where I could, though some are now pointing at search result pages instead of specific products.
