### PR TITLE
wrong diagram for rgb-rainbow

### DIFF
--- a/docs/led-rainbow.md
+++ b/docs/led-rainbow.md
@@ -17,9 +17,9 @@ Demonstrates use of an RGB LED (common cathode) by setting its color to red (`#f
 Basic example with RGB LED connected to pins 6, 5, and 3 for red, green, and blue respectively. The common pin is connected to ground.
 
 
-![docs/breadboard/led-rgb-anode.png](breadboard/led-rgb-anode.png)<br>
+![docs/breadboard/led-rgb.png](breadboard/led-rgb.png)<br>
 
-Fritzing diagram: [docs/breadboard/led-rgb-anode.fzz](breadboard/led-rgb-anode.fzz)
+Fritzing diagram: [docs/breadboard/led-rgb.fzz](breadboard/led-rgb.fzz)
 
 &nbsp;
 

--- a/docs/led-rgb.md
+++ b/docs/led-rgb.md
@@ -11,7 +11,7 @@ Demonstrates use of an RGB LED (common cathode) by setting its color to red (`#f
 
 
 
-### RGB LED. (Arduino UNO)
+### Common Cathode RGB LED. (Arduino UNO)
 
 
 Basic example with RGB LED connected to pins 6, 5, and 3 for red, green, and blue respectively.

--- a/tpl/programs.json
+++ b/tpl/programs.json
@@ -165,7 +165,7 @@
         "title": "LED - RGB",
         "description": "Demonstrates use of an RGB LED (common cathode) by setting its color to red (`#ff0000`) and making it blink. Requires RGB LED on pins that support PWM (usually denoted by ~).",
         "breadboards": [
-          {"name": "led-rgb", "title": "RGB LED. (Arduino UNO)", "description": "Basic example with RGB LED connected to pins 6, 5, and 3 for red, green, and blue respectively."}
+          {"name": "led-rgb", "title": "Common Cathode RGB LED. (Arduino UNO)", "description": "Basic example with RGB LED connected to pins 6, 5, and 3 for red, green, and blue respectively."}
         ]
       },
          {
@@ -186,7 +186,7 @@
         "title": "LED - Rainbow",
         "description": "Demonstrates use of an RGB LED (common cathode) by setting its color to red (`#ff0000`) and making it blink. Requires RGB LED on pins that support PWM (usually denoted by ~).",
         "breadboards": [
-          {"name": "led-rgb-anode", "title": "Common Cathode RGB LED. (Arduino UNO)", "description": "Basic example with RGB LED connected to pins 6, 5, and 3 for red, green, and blue respectively. The common pin is connected to ground."}
+          {"name": "led-rgb", "title": "Common Cathode RGB LED. (Arduino UNO)", "description": "Basic example with RGB LED connected to pins 6, 5, and 3 for red, green, and blue respectively. The common pin is connected to ground."}
         ]
       },
       {


### PR DESCRIPTION
the example erroneously had common-anode diagram, but example used
common-cathode