### PR TITLE
Fix nanotimer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "ease-component": "latest",
     "es6-shim": "latest",
     "lodash": "latest",
-    "nanotimer": "0.3.1",
+    "nanotimer": "~0.3.1",
     "temporal": "latest",
     "array-includes": "latest"
   },


### PR DESCRIPTION
The nanotimer dependency was locked to a specific version.
This prevented newer patch releases supporting io.js from being used.