### PR TITLE
Temperature: add analog reference to TMP36 controller

### DIFF
--- a/lib/temperature.js
+++ b/lib/temperature.js
@@ -188,7 +188,11 @@ var Controllers = {
     },
     toCelsius: {
       value: function(raw) {
-        return (raw * 0.4882814) - 50;
+        // Analog Reference Voltage
+        var volts = raw * this.aref / 1024;
+
+        // tempC = (mV / 10) - 50
+        return (volts * 100) - 50;
       }
     }
   },
@@ -368,11 +372,14 @@ function Temperature(opts) {
     return new Temperature(opts);
   }
 
-  Board.Device.call(
+  Board.Component.call(
     this, opts = Board.Options(opts)
   );
 
   freq = opts.freq || 25;
+
+  // Analog Reference Voltage (default to board.io.aref || 5)
+  this.aref = opts.aref || this.io.aref || 5;
 
   if (opts.controller && typeof opts.controller === "string") {
     controller = Controllers[opts.controller.toUpperCase()];

--- a/lib/temperature.js
+++ b/lib/temperature.js
@@ -2,6 +2,7 @@ var Board = require("../lib/board.js"),
   Emitter = require("events").EventEmitter,
   util = require("util");
 
+var CELSIUS_TO_KELVIN = 273.15;
 
 function analogHandler(opts, dataHandler) {
   var pin = opts.pin;
@@ -156,27 +157,36 @@ var Controllers = {
       value: analogHandler
     }
   },
-  //http://www.ti.com/lit/ds/symlink/lm35.pdf
   LM35: {
     initialize: {
       value: analogHandler
     },
     toCelsius: {
       value: function(raw) {
-        return (5.0 * raw * 100.0) / 1024.0;
+        // http://www.ti.com/lit/ds/symlink/lm35.pdf
+        // VOUT = 1500 mV at 150°C
+        // VOUT = 250 mV at 25°C
+        // VOUT = –550 mV at –55°C
+
+        var mV = this.aref * 1000 * raw / 1024;
+
+        // 10mV = 1°C
+        return mV / 10;
       }
     }
   },
-  //http://www.ti.com/lit/ds/symlink/lm335.pdf
   LM335: {
     initialize: {
       value: analogHandler
     },
     toCelsius: {
       value: function(raw) {
-        var mv = (raw / 1024.0) * 5000;
-        var k = (mv / 10);
-        return (k - 273.15);
+        // http://www.ti.com/lit/ds/symlink/lm335.pdf
+        // OUTPUT 10mV/°K
+
+        var mV = this.aref * 1000 * raw / 1024;
+
+        return (mV / 10) - CELSIUS_TO_KELVIN;
       }
     }
   },
@@ -189,10 +199,10 @@ var Controllers = {
     toCelsius: {
       value: function(raw) {
         // Analog Reference Voltage
-        var volts = raw * this.aref / 1024;
+        var mV = this.aref * 1000 * raw / 1024;
 
         // tempC = (mV / 10) - 50
-        return (volts * 100) - 50;
+        return (mV / 10) - 50;
       }
     }
   },
@@ -291,8 +301,8 @@ var Controllers = {
         var adcres = 1023;
         // Beta parameter
         var beta = 3975;
-        // 0°C = 273.15 K
-        var kelvin = 273.15;
+        // 0°C = CELSIUS_TO_KELVIN K
+        var kelvin = CELSIUS_TO_KELVIN;
         // 10 kOhm (sensor resistance)
         var rb = 10000;
         // Ginf = 1/Rinf
@@ -315,7 +325,7 @@ var Controllers = {
       value: function(raw) {
         var adcres = 1023;
         var beta = 3950;
-        var kelvin = 273.15;
+        var kelvin = CELSIUS_TO_KELVIN;
         var rb = 10000; // 10 kOhm
         var ginf = 120.6685; // Ginf = 1/Rinf
 
@@ -412,7 +422,7 @@ function Temperature(opts) {
     },
     kelvin: {
       get: function() {
-        return this.celsius + 273.15;
+        return this.celsius + CELSIUS_TO_KELVIN;
       }
     }
   };  

--- a/test/temperature.js
+++ b/test/temperature.js
@@ -76,7 +76,7 @@ function makeTestAnalogConversion(opts) {
     test.equal(Math.round(this.temperature.K), opts.K, "temp.K");
     test.equal(Math.round(this.temperature.kelvin), opts.K, "temp.kelvin");
     test.equal(Math.round(this.temperature.F), opts.F, "temp.F");
-    test.equal(Math.round(this.temperature.fahrenheit), opts.F, "temp.F");
+    test.equal(Math.round(this.temperature.fahrenheit), opts.F, "temp.fahrenheit");
 
     this.clock.tick(this.freq);
 
@@ -88,7 +88,7 @@ function makeTestAnalogConversion(opts) {
     test.equal(Math.round(data.K), opts.K, "data.K");
     test.equal(Math.round(data.kelvin), opts.K, "data.kelvin");
     test.equal(Math.round(data.F), opts.F, "data.F");
-    test.equal(Math.round(data.fahrenheit), opts.F, "data.F");
+    test.equal(Math.round(data.fahrenheit), opts.F, "data.fahrenheit");
 
     this.clock.tick(this.freq);
 

--- a/test/temperature.js
+++ b/test/temperature.js
@@ -150,6 +150,29 @@ exports["Temperature -- ANALOG"] = {
     done();
   },
 
+  "picks aref from board.io": function(test) {
+    this.board.io.aref = 3.3;
+    this.temperature = createAnalog.call(this);
+    test.expect(1);
+
+    test.equal(this.temperature.aref, this.board.io.aref);
+    test.done();
+  },
+
+  "picks aref from options": function(test) {
+    this.board.io.aref = 3.3;
+    this.temperature = new Temperature({
+      aref: 1.8,
+      pins: ["A0"],
+      freq: this.freq,
+      board: this.board
+    });
+    test.expect(1);
+
+    test.equal(this.temperature.aref, 1.8);
+    test.done();
+  },
+
   "no controller": {
     setUp: function(done) {
       this.temperature = createAnalog.call(this);
@@ -251,108 +274,43 @@ exports["Temperature -- ANALOG"] = {
       K: 338
     }),
     data: makeTestAnalogConversion({
-      raw: 100,
-      C: 49,
-      F: 120,
-      K: 322
+      raw: 200,
+      C: 98,
+      F: 208,
+      K: 371
     }),
     change: testAnalogChange,
-  }
-};
-
-exports["Temperature -- TMP36"] = {
-
-  setUp: function(done) {
-    this.analogRead = this.sinon.spy(MockFirmata.prototype, "analogRead");
-
-    done();
   },
 
-  data: function(test) {
-    this.temperature = new Temperature({
-      controller: "TMP36",
-      pins: ["A0"],
-      freq: 100,
-      board: this.board
-    });
+  TMP36: {
+    setUp: function(done) {
+      this.temperature = new Temperature({
+        controller: "TMP36",
+        pins: ["A0"],
+        freq: this.freq,
+        board: this.board
+      });
+      done();
+    },
 
-    var raw = this.analogRead.args[0][1],
-      spy = this.sinon.spy();
+    shape: testShape,
+    change: testAnalogChange,
 
-    test.expect(4);
-    this.temperature.on("data", spy);
+    aref: makeTestAnalogConversion({
+      aref: 3.3,
+      raw: 150,
+      C: -2,
+      F: 29,
+      K: 271
+    }),
 
-    raw(150);
-
-    this.clock.tick(100);
-
-    test.ok(spy.calledOnce);
-    test.equals(Math.round(spy.args[0][1].celsius), 23);
-    test.equals(Math.round(spy.args[0][1].fahrenheit), 74);
-    test.equals(Math.round(spy.args[0][1].kelvin), 296);
-
-    test.done();
+    data: makeTestAnalogConversion({
+      raw: 150,
+      C: 23,
+      F: 74,
+      K: 296
+    }),
   },
-
-  aref: function(test) {
-    this.temperature = new Temperature({
-      controller: "TMP36",
-      pins: ["A0"],
-      freq: 100,
-      board: this.board,
-      aref: 3.3
-    });
-
-    var raw = this.analogRead.args[0][1],
-      spy = this.sinon.spy();
-
-    test.expect(7);
-    this.temperature.on("data", spy);
-
-    raw(150);
-
-    this.clock.tick(100);
-
-    test.ok(spy.calledOnce);
-    test.equals(Math.round(spy.args[0][1].C), -2);
-    test.equals(Math.round(spy.args[0][1].F), 29);
-    test.equals(Math.round(spy.args[0][1].K), 271);
-
-    // changing aref changes values
-    this.temperature.aref = 1.8;
-    test.equals(Math.round(this.temperature.C), -24);
-    test.equals(Math.round(this.temperature.F), -11);
-    test.equals(Math.round(this.temperature.K), 250);
-
-    test.done();
-  },
-
-  arefFromIo: function(test) {
-    this.board.io.aref = 3.3;
-    this.temperature = new Temperature({
-      controller: "TMP36",
-      pins: ["A0"],
-      freq: 100,
-      board: this.board,
-    });
-
-    var raw = this.analogRead.args[0][1],
-      spy = this.sinon.spy();
-
-    test.expect(4);
-    this.temperature.on("data", spy);
-
-    raw(150);
-
-    this.clock.tick(100);
-
-    test.ok(spy.calledOnce);
-    test.equals(Math.round(spy.args[0][1].C), -2);
-    test.equals(Math.round(spy.args[0][1].F), 29);
-    test.equals(Math.round(spy.args[0][1].K), 271);
-
-    test.done();
-  }
 };
 
 function createDS18B20(pin, address) {

--- a/test/temperature.js
+++ b/test/temperature.js
@@ -37,7 +37,7 @@ exports.setUp = function(done) {
   }];
 
   this.board = newBoard();
-  this.sinon = sinon.sandbox.create();
+  this.sandbox = sinon.sandbox.create();
   this.clock = sinon.useFakeTimers();
   this.freq = 100;
 
@@ -46,7 +46,7 @@ exports.setUp = function(done) {
 
 exports.tearDown = function(done) {
   Board.purge();
-  this.sinon.restore();
+  this.sandbox.restore();
   this.clock.restore();
   done();
 };
@@ -62,7 +62,7 @@ function createAnalog(toCelsius) {
 
 function makeTestAnalogConversion(opts) {
   return function testAnalogConversion(test) {
-    var spy = this.sinon.spy();
+    var spy = this.sandbox.spy();
     test.expect(15);
     if (opts.aref) {
       this.temperature.aref = opts.aref;
@@ -99,7 +99,7 @@ function makeTestAnalogConversion(opts) {
 
 function testAnalogChange(test) {
   var raw = this.analogRead.firstCall.yield.bind(this.analogRead.firstCall),
-    spy = this.sinon.spy();
+    spy = this.sandbox.spy();
 
   test.expect(1);
   this.temperature.on("change", spy);
@@ -143,7 +143,7 @@ function testShape(test) {
 
 exports["Temperature -- ANALOG"] = {
   setUp: function(done) {
-    this.analogRead = this.sinon.stub(MockFirmata.prototype, "analogRead");
+    this.analogRead = this.sandbox.stub(MockFirmata.prototype, "analogRead");
     this.analogRead.yields(0);
     this.proto.push({ name: "toCelsius" });
 
@@ -192,7 +192,7 @@ exports["Temperature -- ANALOG"] = {
 
   "custom toCelsius": {
     setUp: function(done) {
-      this.toCelsius = this.sinon.stub().returns(22);
+      this.toCelsius = this.sandbox.stub().returns(22);
       this.temperature = createAnalog.call(this, this.toCelsius);
       done();
     },
@@ -327,12 +327,12 @@ exports["Temperature -- DS18B20"] = {
 
   setUp: function(done) {
     this.pin = 2;
-    this.sendOneWireConfig = this.sinon.spy(MockFirmata.prototype, "sendOneWireConfig");
-    this.sendOneWireSearch = this.sinon.spy(MockFirmata.prototype, "sendOneWireSearch");
-    this.sendOneWireDelay = this.sinon.spy(MockFirmata.prototype, "sendOneWireDelay");
-    this.sendOneWireReset = this.sinon.spy(MockFirmata.prototype, "sendOneWireReset");
-    this.sendOneWireWrite = this.sinon.spy(MockFirmata.prototype, "sendOneWireWrite");
-    this.sendOneWireWriteAndRead = this.sinon.spy(MockFirmata.prototype, "sendOneWireWriteAndRead");
+    this.sendOneWireConfig = this.sandbox.spy(MockFirmata.prototype, "sendOneWireConfig");
+    this.sendOneWireSearch = this.sandbox.spy(MockFirmata.prototype, "sendOneWireSearch");
+    this.sendOneWireDelay = this.sandbox.spy(MockFirmata.prototype, "sendOneWireDelay");
+    this.sendOneWireReset = this.sandbox.spy(MockFirmata.prototype, "sendOneWireReset");
+    this.sendOneWireWrite = this.sandbox.spy(MockFirmata.prototype, "sendOneWireWrite");
+    this.sendOneWireWriteAndRead = this.sandbox.spy(MockFirmata.prototype, "sendOneWireWriteAndRead");
 
     done();
   },
@@ -367,7 +367,7 @@ exports["Temperature -- DS18B20"] = {
   data: function(test) {
     var device = [0x28, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0xFF];
     var search, data;
-    var spy = this.sinon.spy();
+    var spy = this.sandbox.spy();
 
     test.expect(18);
 
@@ -428,8 +428,8 @@ exports["Temperature -- DS18B20"] = {
   },
 
   twoAddressedUnits: function(test) {
-    var spyA = this.sinon.spy();
-    var spyB = this.sinon.spy();
+    var spyA = this.sandbox.spy();
+    var spyB = this.sandbox.spy();
     var deviceA = [0x28, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0xFF];
     var deviceB = [0x28, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0xFF];
     var search, data;
@@ -479,9 +479,9 @@ exports["Temperature -- DS18B20"] = {
 exports["Temperature -- MPU6050"] = {
 
   setUp: function(done) {
-    this.i2cConfig = this.sinon.spy(MockFirmata.prototype, "i2cConfig");
-    this.i2cWrite = this.sinon.spy(MockFirmata.prototype, "i2cWrite");
-    this.i2cRead = this.sinon.spy(MockFirmata.prototype, "i2cRead");
+    this.i2cConfig = this.sandbox.spy(MockFirmata.prototype, "i2cConfig");
+    this.i2cWrite = this.sandbox.spy(MockFirmata.prototype, "i2cWrite");
+    this.i2cRead = this.sandbox.spy(MockFirmata.prototype, "i2cRead");
     this.temperature = new Temperature({
       controller: "MPU6050",
       freq: 100,
@@ -512,7 +512,7 @@ exports["Temperature -- MPU6050"] = {
     test.done();
   },
   data: function(test) {
-    var read, spy = this.sinon.spy();
+    var read, spy = this.sandbox.spy();
 
     test.expect(12);
     this.temperature.on("data", spy);
@@ -551,7 +551,7 @@ exports["Temperature -- MPU6050"] = {
 exports["Temperature -- GROVE"] = {
 
   setUp: function(done) {
-    this.analogRead = this.sinon.spy(MockFirmata.prototype, "analogRead");
+    this.analogRead = this.sandbox.spy(MockFirmata.prototype, "analogRead");
     this.temperature = new Temperature({
       controller: "GROVE",
       pin: "A0",
@@ -564,7 +564,7 @@ exports["Temperature -- GROVE"] = {
 
   data: function(test) {
     var raw = this.analogRead.args[0][1],
-      spy = this.sinon.spy();
+      spy = this.sandbox.spy();
 
     test.expect(4);
     this.temperature.on("data", spy);
@@ -585,7 +585,7 @@ exports["Temperature -- GROVE"] = {
 exports["Temperature -- TINKERKIT"] = {
 
   setUp: function(done) {
-    this.analogRead = this.sinon.spy(MockFirmata.prototype, "analogRead");
+    this.analogRead = this.sandbox.spy(MockFirmata.prototype, "analogRead");
     this.temperature = new Temperature({
       controller: "TINKERKIT",
       pin: "A0",
@@ -599,7 +599,7 @@ exports["Temperature -- TINKERKIT"] = {
   data: function(test) {
 
     var raw = this.analogRead.args[0][1],
-      spy = this.sinon.spy();
+      spy = this.sandbox.spy();
 
     test.expect(4);
     this.temperature.on("data", spy);
@@ -620,10 +620,10 @@ exports["Temperature -- TINKERKIT"] = {
 exports["Temperature -- MPL115A2"] = {
 
   setUp: function(done) {
-    this.i2cConfig = this.sinon.spy(MockFirmata.prototype, "i2cConfig");
-    this.i2cWrite = this.sinon.spy(MockFirmata.prototype, "i2cWrite");
-    this.i2cRead = this.sinon.spy(MockFirmata.prototype, "i2cRead");
-    this.i2cReadOnce = this.sinon.spy(MockFirmata.prototype, "i2cReadOnce");
+    this.i2cConfig = this.sandbox.spy(MockFirmata.prototype, "i2cConfig");
+    this.i2cWrite = this.sandbox.spy(MockFirmata.prototype, "i2cWrite");
+    this.i2cRead = this.sandbox.spy(MockFirmata.prototype, "i2cRead");
+    this.i2cReadOnce = this.sandbox.spy(MockFirmata.prototype, "i2cReadOnce");
 
     this.temperature = new Temperature({
       controller: "MPL115A2",
@@ -707,8 +707,8 @@ exports["Temperature -- MPL115A2"] = {
 exports["Temperature -- SI7020"] = {
 
   setUp: function(done) {
-    this.i2cConfig = this.sinon.spy(MockFirmata.prototype, "i2cConfig");
-    this.i2cRead = this.sinon.spy(MockFirmata.prototype, "i2cRead");
+    this.i2cConfig = this.sandbox.spy(MockFirmata.prototype, "i2cConfig");
+    this.i2cRead = this.sandbox.spy(MockFirmata.prototype, "i2cRead");
 
     this.temperature = new Temperature({
       controller: "SI7020",
@@ -769,7 +769,7 @@ exports["Temperature -- SI7020"] = {
     // byte count
     test.equal(this.i2cRead.lastCall.args[2], 2);
 
-    var spy = this.sinon.spy();
+    var spy = this.sandbox.spy();
     var read = this.i2cRead.lastCall.args[3];
 
     this.temperature.on("data", spy);

--- a/test/temperature.js
+++ b/test/temperature.js
@@ -4,20 +4,6 @@ var MockFirmata = require("./util/mock-firmata"),
   Board = five.Board,
   Temperature = five.Temperature;
 
-function shapeTests(test) {
-  test.expect(this.proto.length + this.instance.length);
-
-  this.proto.forEach(function testProtoMethods(method) {
-    test.equal(typeof this.temperature[method.name], "function", method.name);
-  }, this);
-
-  this.instance.forEach(function testInstanceProperties(property) {
-    test.notEqual(typeof this.temperature[property.name], "undefined", property.name);
-  }, this);
-
-  test.done();
-}
-
 function newBoard() {
   var io = new MockFirmata();
   var board = new Board({
@@ -53,6 +39,8 @@ exports.setUp = function(done) {
   this.board = newBoard();
   this.sinon = sinon.sandbox.create();
   this.clock = sinon.useFakeTimers();
+  this.freq = 100;
+
   done();
 };
 
@@ -67,15 +55,96 @@ function createAnalog(toCelsius) {
   return new Temperature({
     pins: ["A0"],
     toCelsius: toCelsius,
-    freq: 100,
+    freq: this.freq,
     board: this.board
   });
 }
 
+function makeTestAnalogConversion(opts) {
+  return function testAnalogConversion(test) {
+    var spy = this.sinon.spy();
+    test.expect(15);
+    if (opts.aref) {
+      this.temperature.aref = opts.aref;
+    }
+    this.temperature.on("data", spy);
+    this.analogRead.firstCall.yield(opts.raw);
+
+    test.equal(spy.callCount, 0);
+    test.equal(Math.round(this.temperature.C), opts.C, "temp.C");
+    test.equal(Math.round(this.temperature.celsius), opts.C, "temp.celsius");
+    test.equal(Math.round(this.temperature.K), opts.K, "temp.K");
+    test.equal(Math.round(this.temperature.kelvin), opts.K, "temp.kelvin");
+    test.equal(Math.round(this.temperature.F), opts.F, "temp.F");
+    test.equal(Math.round(this.temperature.fahrenheit), opts.F, "temp.F");
+
+    this.clock.tick(this.freq);
+
+    test.equal(spy.callCount, 1);
+
+    var data = spy.firstCall.args[1];
+    test.equal(Math.round(data.C), opts.C, "data.C");
+    test.equal(Math.round(data.celsius), opts.C, "data.celsius");
+    test.equal(Math.round(data.K), opts.K, "data.K");
+    test.equal(Math.round(data.kelvin), opts.K, "data.kelvin");
+    test.equal(Math.round(data.F), opts.F, "data.F");
+    test.equal(Math.round(data.fahrenheit), opts.F, "data.F");
+
+    this.clock.tick(this.freq);
+
+    test.equal(spy.callCount, 2);
+    test.done();
+  };
+}
+
+function testAnalogChange(test) {
+  var raw = this.analogRead.firstCall.yield.bind(this.analogRead.firstCall),
+    spy = this.sinon.spy();
+
+  test.expect(1);
+  this.temperature.on("change", spy);
+
+  raw(100);
+  this.clock.tick(this.freq);
+
+  raw(100);
+  this.clock.tick(this.freq);
+
+  raw(200);
+  this.clock.tick(this.freq);
+
+  raw(100);
+  this.clock.tick(this.freq);
+
+  raw(200);
+  this.clock.tick(this.freq);
+
+  raw(200);
+  this.clock.tick(this.freq);
+
+  test.equal(spy.callCount, 4);
+  test.done();
+}
+
+function testShape(test) {
+  test.expect(this.proto.length + this.instance.length);
+
+  this.proto.forEach(function testProtoMethods(method) {
+    test.equal(typeof this.temperature[method.name], "function", method.name);
+  }, this);
+
+  this.instance.forEach(function testInstanceProperties(property) {
+    test.notEqual(typeof this.temperature[property.name], "undefined", property.name);
+  }, this);
+
+  test.done();
+}
+
+
 exports["Temperature -- ANALOG"] = {
   setUp: function(done) {
     this.analogRead = this.sinon.stub(MockFirmata.prototype, "analogRead");
-    this.analogRead.yields(50);
+    this.analogRead.yields(0);
     this.proto.push({ name: "toCelsius" });
 
     done();
@@ -87,190 +156,107 @@ exports["Temperature -- ANALOG"] = {
       done();
     },
 
-    shape: shapeTests,
+    shape: testShape,
+    change: testAnalogChange,
 
-    rawData: function(test) {
-      var spy = this.sinon.spy();
+    rawData: makeTestAnalogConversion({
+      raw: 50,
+      C: 50,
+      F: 122,
+      K: 323
+    }),
+  },
 
-      test.expect(13);
-      this.temperature.on("data", spy);
+  "custom toCelsius": {
+    setUp: function(done) {
+      this.toCelsius = this.sinon.stub().returns(22);
+      this.temperature = createAnalog.call(this, this.toCelsius);
+      done();
+    },
+    shape: testShape,
+    conversion: makeTestAnalogConversion({
+      raw: 50,
+      C: 22,
+      F: 72,
+      K: 295
+    }),
+    "raw doesnt matter": makeTestAnalogConversion({
+      raw: 100,
+      C: 22,
+      F: 72,
+      K: 295
+    }),
+    "toCelsius receives raw": function(test) {
+      test.expect(6);
+      this.analogRead.yield(10);
+      test.equal(this.toCelsius.callCount, 0);
 
-      this.clock.tick(100);
+      test.equal(this.temperature.C, 22);
+      test.equal(this.toCelsius.callCount, 1);
+      test.equal(this.toCelsius.firstCall.args[0], 10);
+      this.toCelsius.reset();
 
-      test.ok(spy.calledOnce);
-      var data = spy.firstCall.args[1];
-
-      var expected = {
-        celsius: 50,
-        C: 50,
-        fahrenheit: 122,
-        F: 122,
-        kelvin: 323,
-        K: 323,
-      };
-
-      Object.keys(expected).forEach(function(prop) {
-        test.equal(Math.round(data[prop]), expected[prop], "data event." + prop);
-        test.equal(Math.round(this.temperature[prop]), expected[prop], "temperature." + prop);
-      }, this);
-
+      this.analogRead.yield(100);
+      test.equal(this.temperature.C, 22);
+      test.equal(this.toCelsius.firstCall.args[0], 100);
       test.done();
     },
   },
 
-  customData: function(test) {
-    var spy = this.sinon.spy();
-    this.temperature = createAnalog.call(this, function toCelsius() { return 22; });
+  LM335: {
+    setUp: function(done) {
+      this.temperature = new Temperature({
+        controller: "LM335",
+        pins: ["A0"],
+        freq: 100,
+        board: this.board
+      });
 
-    test.expect(7);
-    this.temperature.on("data", spy);
-
-    this.clock.tick(100);
-
-    test.ok(spy.calledOnce);
-    var data = spy.firstCall.args[1];
-    test.equals(Math.round(data.celsius), 22, "celsius");
-    test.equals(Math.round(data.C), 22, "C");
-    test.equals(Math.round(data.fahrenheit), 72, "fahrenheit");
-    test.equals(Math.round(data.F), 72, "F");
-    test.equals(Math.round(data.kelvin), 295, "kelvin");
-    test.equals(Math.round(data.K), 295, "K");
-
-    test.done();
+      done();
+    },
+    shape: testShape,
+    aref: makeTestAnalogConversion({
+      aref: 3.3,
+      raw: 950,
+      C: 33,
+      F: 91,
+      K: 306
+    }),
+    data: makeTestAnalogConversion({
+      raw: 100,
+      C: -224,
+      F: -372,
+      K: 49,
+    }),
+    change: testAnalogChange,
   },
-};
+  LM35: {
+    setUp: function(done) {
+      this.temperature = new Temperature({
+        controller: "LM35",
+        pins: ["A0"],
+        freq: 100,
+        board: this.board
+      });
 
-exports["Temperature -- LM335"] = {
+      done();
+    },
 
-  setUp: function(done) {
-    this.analogRead = this.sinon.spy(MockFirmata.prototype, "analogRead");
-    this.temperature = new Temperature({
-      controller: "LM335",
-      pins: ["A0"],
-      freq: 100,
-      board: this.board
-    });
-
-    done();
-  },
-
-  shape: shapeTests,
-
-  data: function(test) {
-
-    var raw = this.analogRead.args[0][1],
-      spy = this.sinon.spy();
-
-    test.expect(4);
-    this.temperature.on("data", spy);
-
-    raw(100);
-
-    this.clock.tick(100);
-
-    test.ok(spy.calledOnce);
-    test.equals(Math.round(spy.args[0][1].celsius), -224);
-    test.equals(Math.round(spy.args[0][1].fahrenheit), -372);
-    test.equals(Math.round(spy.args[0][1].kelvin), 49);
-
-    test.done();
-  },
-
-  change: function(test) {
-    var raw = this.analogRead.args[0][1],
-      spy = this.sinon.spy();
-
-    test.expect(1);
-    this.temperature.on("change", spy);
-
-    raw(100);
-    this.clock.tick(100);
-
-    raw(100);
-    this.clock.tick(100);
-
-    raw(200);
-    this.clock.tick(100);
-
-    raw(100);
-    this.clock.tick(100);
-
-    raw(200);
-    this.clock.tick(100);
-
-    raw(200);
-    this.clock.tick(100);
-
-    test.equal(spy.callCount, 4);
-    test.done();
-  }
-};
-
-
-
-exports["Temperature -- LM35"] = {
-
-  setUp: function(done) {
-    this.analogRead = this.sinon.spy(MockFirmata.prototype, "analogRead");
-    this.temperature = new Temperature({
-      controller: "LM35",
-      pins: ["A0"],
-      freq: 100,
-      board: this.board
-    });
-
-    done();
-  },
-
-  shape: shapeTests,
-
-  data: function(test) {
-
-    var raw = this.analogRead.args[0][1],
-      spy = this.sinon.spy();
-
-    test.expect(4);
-    this.temperature.on("data", spy);
-
-    raw(100);
-
-    this.clock.tick(100);
-
-    test.ok(spy.calledOnce);
-    test.equals(Math.round(spy.args[0][1].celsius), 49);
-    test.equals(Math.round(spy.args[0][1].fahrenheit), 120);
-    test.equals(Math.round(spy.args[0][1].kelvin), 322);
-
-    test.done();
-  },
-
-  change: function(test) {
-    var raw = this.analogRead.args[0][1],
-      spy = this.sinon.spy();
-
-    test.expect(1);
-    this.temperature.on("change", spy);
-
-    raw(100);
-    this.clock.tick(100);
-
-    raw(100);
-    this.clock.tick(100);
-
-    raw(200);
-    this.clock.tick(100);
-
-    raw(100);
-    this.clock.tick(100);
-
-    raw(200);
-    this.clock.tick(100);
-
-    raw(200);
-    this.clock.tick(100);
-
-    test.equal(spy.callCount, 4);
-    test.done();
+    shape: testShape,
+    aref: makeTestAnalogConversion({
+      aref: 3.3,
+      raw: 200,
+      C: 64,
+      F: 148,
+      K: 338
+    }),
+    data: makeTestAnalogConversion({
+      raw: 100,
+      C: 49,
+      F: 120,
+      K: 322
+    }),
+    change: testAnalogChange,
   }
 };
 


### PR DESCRIPTION
This code adds an `aref` property to the `Temperature` object.  Defaults to whatever is defined on `this.io.aref` OR `5` if not defined at all.

This allows you to set the analog reference voltage for analog style temp controllers, first implementation I targeted the `TMP36` and will add to the rest of the analog controllers before we land this PR if this first one went well.