### PR TITLE
Allow digital sensor constructor to take string pin names

### DIFF
--- a/lib/johnny-five.js
+++ b/lib/johnny-five.js
@@ -74,7 +74,7 @@ module.exports.Analog = function(opts) {
 module.exports.Digital = function(opts) {
   var pin;
 
-  if (typeof opts === "number") {
+  if (typeof opts === "number" || typeof opts === "string") {
     pin = opts;
     opts = {
       type: "digital",


### PR DESCRIPTION
This is a fix for https://github.com/nebrius/raspi-io/issues/33.

tl;dr, pins are usually expressed as strings for the RPi because it's pin naming scheme is wack. Currently, it thinks this is giving the constructor a dictionary of options, instead of a pin name:

```
new five.Sensor.Digital('GPIO6');
```

This PR allows pins to be number _or_ strings, but assumes everything else is a dictionary of options.