### PR TITLE
Add support for Tessel Servo module to Servo and LED

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ To interactively navigate the examples, visit the [Johnny-Five examples](http://
 ### LED
 - [LED](https://github.com/rwaldron/johnny-five/blob/master/docs/led.md)
 - [LED - PCA9685](https://github.com/rwaldron/johnny-five/blob/master/docs/led-PCA9685.md)
+- [LED - Tessel Servo Module](https://github.com/rwaldron/johnny-five/blob/master/docs/led-tessel-servo-module.md)
 - [LED - Blink](https://github.com/rwaldron/johnny-five/blob/master/docs/led-blink.md)
 - [LED - Pulse](https://github.com/rwaldron/johnny-five/blob/master/docs/led-pulse.md)
 - [LED - Pulse with animation](https://github.com/rwaldron/johnny-five/blob/master/docs/led-pulse-animation.md)
@@ -216,6 +217,7 @@ To interactively navigate the examples, visit the [Johnny-Five examples](http://
 ### Servo
 - [Servo](https://github.com/rwaldron/johnny-five/blob/master/docs/servo.md)
 - [Servo - PCA9685](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-PCA9685.md)
+- [Servo - Tessel Servo Module](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-tessel-servo-module.md)
 - [Servo - Continuous](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-continuous.md)
 - [Servo - Slider control](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-slider.md)
 - [Servo - Prompt](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-prompt.md)

--- a/docs/led-tessel-servo-module.md
+++ b/docs/led-tessel-servo-module.md
@@ -1,0 +1,71 @@
+<!--remove-start-->
+
+# LED - Tessel Servo Module
+
+<!--remove-end-->
+
+
+
+
+
+
+
+
+Run with:
+```bash
+node eg/led-tessel-servo-module.js
+```
+
+
+```javascript
+var five = require("johnny-five");
+var Tessel = require("tessel-io");
+
+var board = new five.Board({
+  io: new Tessel()
+});
+
+board.on("ready", function() {
+  var led = new five.Led({
+    pin: process.argv[2] || 1,
+    address: 0x73,
+    port: "A",
+    controller: "PCA9685"
+  });
+
+  // address: The address of the shield.
+  //    Defaults to 0x40
+  // pin: The pin the LED is connected to
+  //    Defaults to 0
+  // controller: The type of controller being used.
+  //   Defaults to "standard".
+  // port: The Tessel port being used "A" or "B"
+
+  // Add LED to REPL (optional)
+  this.repl.inject({
+    led: led
+  });
+
+  led.pulse();
+});
+
+```
+
+
+
+
+
+
+
+
+&nbsp;
+
+<!--remove-start-->
+
+## License
+Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
+Licensed under the MIT license.
+Copyright (c) 2014, 2015 The Johnny-Five Contributors
+Licensed under the MIT license.
+
+<!--remove-end-->

--- a/docs/servo-tessel-servo-module.md
+++ b/docs/servo-tessel-servo-module.md
@@ -1,0 +1,61 @@
+<!--remove-start-->
+
+# Servo - Tessel Servo Module
+
+<!--remove-end-->
+
+
+
+
+
+
+
+
+Run with:
+```bash
+node eg/servo-tessel-servo-module.js
+```
+
+
+```javascript
+var five = require("johnny-five");
+var Tessel = require("tessel-io");
+
+var board = new five.Board({
+  io: new Tessel()
+});
+
+board.on("ready", function() {
+  console.log("Connected");
+
+  // Initialize the servo instance
+  var servo = new five.Servo({
+    controller: "PCA9685",
+    port: "A",
+    address: 0x73,
+    pin: 1,
+  });
+
+  servo.sweep();
+});
+
+```
+
+
+
+
+
+
+
+
+&nbsp;
+
+<!--remove-start-->
+
+## License
+Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
+Licensed under the MIT license.
+Copyright (c) 2014, 2015 The Johnny-Five Contributors
+Licensed under the MIT license.
+
+<!--remove-end-->

--- a/eg/led-tessel-servo-module.js
+++ b/eg/led-tessel-servo-module.js
@@ -1,0 +1,30 @@
+var five = require("../lib/johnny-five.js");
+var Tessel = require("tessel-io");
+
+var board = new five.Board({
+  io: new Tessel()
+});
+
+board.on("ready", function() {
+  var led = new five.Led({
+    pin: process.argv[2] || 1,
+    address: 0x73,
+    port: "A",
+    controller: "PCA9685"
+  });
+
+  // address: The address of the shield.
+  //    Defaults to 0x40
+  // pin: The pin the LED is connected to
+  //    Defaults to 0
+  // controller: The type of controller being used.
+  //   Defaults to "standard".
+  // port: The Tessel port being used "A" or "B"
+
+  // Add LED to REPL (optional)
+  this.repl.inject({
+    led: led
+  });
+
+  led.pulse();
+});

--- a/eg/servo-tessel-servo-module.js
+++ b/eg/servo-tessel-servo-module.js
@@ -1,0 +1,20 @@
+var five = require("../lib/johnny-five.js");
+var Tessel = require("tessel-io");
+
+var board = new five.Board({
+  io: new Tessel()
+});
+
+board.on("ready", function() {
+  console.log("Connected");
+
+  // Initialize the servo instance
+  var servo = new five.Servo({
+    controller: "PCA9685",
+    port: "A",
+    address: 0x73,
+    pin: 1,
+  });
+
+  servo.sweep();
+});

--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -57,11 +57,17 @@ var Controllers = {
         var on, off;
         var state = priv.get(this);
         var value = state.isAnode ? 255 - Board.constrain(state.value, 0, 255) : state.value;
+        var pin = this.pin;
 
         on = 0;
         off = this.pwmRange[1] * value / 255;
 
-        this.io.i2cWrite(this.address, [this.REGISTER.LED0_ON_L + 4 * (this.pin), on, on >> 8, off, off >> 8]);
+        // The Tessel Servo module is mislabeled 1 - 16 instead of 0 - 15
+        if (this.board.io.name === "Tessel 2") {
+          pin--;
+        }
+
+        this.io.i2cWrite(this.address, [this.REGISTER.LED0_ON_L + 4 * (pin), on, on >> 8, off, off >> 8]);
       }
     }
   },

--- a/lib/servo.js
+++ b/lib/servo.js
@@ -33,6 +33,11 @@ var Controllers = {
         on = 0;
         off = __.map(degrees, 0, 180, this.pwmRange[0]/4, this.pwmRange[1]/4 );
 
+        // The Tessel Servo module is mislabeled 1 - 16 instead of 0 - 15
+        if (this.board.io.name === "Tessel 2") {
+          pin--;
+        }
+
         this.io.i2cWrite(this.address, [this.REGISTER.LED0_ON_L + 4 * pin, on, on >> 8, off, off >> 8]);
 
       }

--- a/tpl/programs.json
+++ b/tpl/programs.json
@@ -94,6 +94,10 @@
         "description": "Basic LED example using PCA9685"
       },
       {
+        "file": "led-tessel-servo-module.js",
+        "title": "LED - Tessel Servo Module"
+      },
+      {
         "file": "led-blink.js",
         "title": "LED - Blink",
         "description": "Basic LED blink example.",
@@ -273,6 +277,10 @@
       {
         "file": "servo-PCA9685.js",
         "title": "Servo - PCA9685"
+      },
+      {
+        "file": "servo-tessel-servo-module.js",
+        "title": "Servo - Tessel Servo Module"
       },
       {
         "file": "servo-continuous.js",


### PR DESCRIPTION
Notes: Default address is different than most PCA9685, 0x73 instead of 0x40. Also, pins are mis-labeled 1-16 instead of 0-15.