### PR TITLE
added err parameter to function on example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ To interactively navigate the examples, visit the [Johnny-Five examples](http://
 - [Shift Register - Seven segment controller](https://github.com/rwaldron/johnny-five/blob/master/docs/shift-register-seven-segment.md)
 - [Shift Register - Seven segments, daisy chained](https://github.com/rwaldron/johnny-five/blob/master/docs/shift-register-daisy-chain.md)
 
-### Infrared Reflectance)
+### Infrared Reflectance
 - [IR Motion](https://github.com/rwaldron/johnny-five/blob/master/docs/ir-motion.md)
 - [IR Proximity](https://github.com/rwaldron/johnny-five/blob/master/docs/ir-proximity.md)
 - [IR Reflectance](https://github.com/rwaldron/johnny-five/blob/master/docs/ir-reflect.md)

--- a/docs/nunchuk.md
+++ b/docs/nunchuk.md
@@ -98,9 +98,9 @@ board.on("ready", function() {
   //
 
 
-  ["down", "up", "hold"].forEach(function(err, type) {
+  ["down", "up", "hold"].forEach(function(type) {
 
-    nunchuk.on(type, function(event) {
+    nunchuk.on(type, function(err, event) {
       console.log(
         event.target.which + " is " + type,
 

--- a/docs/nunchuk.md
+++ b/docs/nunchuk.md
@@ -55,7 +55,7 @@ board.on("ready", function() {
   // Fired when the joystick detects a change in
   // axis position.
   //
-  nunchuk.joystick.on("change", function(event) {
+  nunchuk.joystick.on("change", function(err, event) {
     console.log(
       "joystick " + event.axis,
       event.target[event.axis],
@@ -68,7 +68,7 @@ board.on("ready", function() {
   // Fired when the accelerometer detects a change in
   // axis position.
   //
-  nunchuk.accelerometer.on("change", function(event) {
+  nunchuk.accelerometer.on("change", function(err, event) {
     console.log(
       "accelerometer " + event.axis,
       event.target[event.axis],
@@ -98,7 +98,7 @@ board.on("ready", function() {
   //
 
 
-  ["down", "up", "hold"].forEach(function(type) {
+  ["down", "up", "hold"].forEach(function(err, type) {
 
     nunchuk.on(type, function(event) {
       console.log(

--- a/eg/nunchuk.js
+++ b/eg/nunchuk.js
@@ -35,7 +35,7 @@ board.on("ready", function() {
   // Fired when the joystick detects a change in
   // axis position.
   //
-  nunchuk.joystick.on("change", function(event) {
+  nunchuk.joystick.on("change", function(err, event) {
     console.log(
       "joystick " + event.axis,
       event.target[event.axis],
@@ -48,7 +48,7 @@ board.on("ready", function() {
   // Fired when the accelerometer detects a change in
   // axis position.
   //
-  nunchuk.accelerometer.on("change", function(event) {
+  nunchuk.accelerometer.on("change", function(err, event) {
     console.log(
       "accelerometer " + event.axis,
       event.target[event.axis],
@@ -78,7 +78,7 @@ board.on("ready", function() {
   //
 
 
-  ["down", "up", "hold"].forEach(function(type) {
+  ["down", "up", "hold"].forEach(function(err, type) {
 
     nunchuk.on(type, function(event) {
       console.log(

--- a/eg/nunchuk.js
+++ b/eg/nunchuk.js
@@ -78,9 +78,9 @@ board.on("ready", function() {
   //
 
 
-  ["down", "up", "hold"].forEach(function(err, type) {
+  ["down", "up", "hold"].forEach(function(type) {
 
-    nunchuk.on(type, function(event) {
+    nunchuk.on(type, function(err, event) {
       console.log(
         event.target.which + " is " + type,
 


### PR DESCRIPTION
Eg/nunchuk.js example wouldn't run with out throwing "Cannot read property 'axis' of null". This is fix by adding err to the function parameters before passing in the event.