### PR TITLE
remove test/ from .npmignore due to #735

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,6 @@ node_modules/
 assets/
 docs/
 eg/
-test/
 tpl/
 util/
 wip/


### PR DESCRIPTION
Changeset 817bc77924500c6351b4cf5d00fac00e8a191a5b breaks modules which relied on the presence of the `mock-firmata` module.

Please accept this PR until #735 can be resolved properly...