### PR TITLE
Increase PWM frequency for PCA9685

### DIFF
--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -21,7 +21,7 @@ var Controllers = {
           controller: this.controller,
           bus: this.bus,
           pwmRange: this.pwmRange,
-          frequency: 50, // Hz
+          frequency: 100, // Hz
         });
 
         this.pin = typeof opts.pin === "undefined" ? 0 : opts.pin;


### PR DESCRIPTION
This will reduce visible PWM flashing with the PCA9685. Mostly noticeable when recording video but also visible with the eye under certain circumstances.