### PR TITLE
Stop continuous rotation servo on instantiation

### DIFF
--- a/docs/servo-continuous.md
+++ b/docs/servo-continuous.md
@@ -42,7 +42,7 @@ board.on("ready", function() {
 
   console.log("Use Up and Down arrows for CW and CCW respectively. Space to stop.");
 
-  var servo = new five.Servo.Continuous(10).stop();
+  var servo = new five.Servo.Continuous(10);
 
   process.stdin.resume();
   process.stdin.setEncoding("utf8");

--- a/eg/servo-continuous.js
+++ b/eg/servo-continuous.js
@@ -9,7 +9,7 @@ board.on("ready", function() {
 
   console.log("Use Up and Down arrows for CW and CCW respectively. Space to stop.");
 
-  var servo = new five.Servo.Continuous(10).stop();
+  var servo = new five.Servo.Continuous(10);
 
   process.stdin.resume();
   process.stdin.setEncoding("utf8");

--- a/lib/servo.js
+++ b/lib/servo.js
@@ -202,6 +202,11 @@ function Servo(opts) {
   if (opts.center) {
     this.center();
   }
+
+  if (opts.type === "continuous") {
+    this.stop();
+  }
+  
 }
 
 util.inherits(Servo, Emitter);

--- a/test/servo.js
+++ b/test/servo.js
@@ -423,6 +423,12 @@ exports["Servo - Continuous"] = {
     test.done();
   },
 
+  stopped: function(test) {
+    test.expect(1);
+    test.ok(this.servoWrite.calledWith(11, 90));
+    test.done();
+  },
+
   cw: function(test) {
     test.expect(2);
 


### PR DESCRIPTION
I can think of no reason why we would not want this to happen. Servo state is a crap shoot otherwise. 

