### PR TITLE
changing this.value to this.scaled to reflect light sensitivity

### DIFF
--- a/docs/sensor-fsr.md
+++ b/docs/sensor-fsr.md
@@ -48,7 +48,7 @@ var five = require("johnny-five"),
       // set the led's brightness based on force
       // applied to force sensitive resistor
 
-      led.brightness(this.value);
+      led.brightness(this.scaled);
     });
   });
 

--- a/eg/sensor-fsr.js
+++ b/eg/sensor-fsr.js
@@ -17,6 +17,6 @@ var five = require("../lib/johnny-five.js"),
       // set the led's brightness based on force
       // applied to force sensitive resistor
 
-      led.brightness(this.value);
+      led.brightness(this.scaled);
     });
   });


### PR DESCRIPTION
Hi! 

`this.value` outputs a really small value which doesn't reflect on the led :|. 
`this.scaled` seems to work better with this example :star2: :tada: