### PR TITLE
Add temporalFallback

### DIFF
--- a/lib/animation.js
+++ b/lib/animation.js
@@ -37,6 +37,20 @@ Animation.normalize = "@@normalize";
 Animation.render = "@@render";
 
 /**
+ * Temporal will run up the CPU. temporalFallback is used
+ * for long running animations.
+ */
+function TemporalFallback(animation) {
+  this.interval = setInterval(function() { animation.loopFunction({calledAt: Date.now()}); }, animation.rate);
+}
+
+TemporalFallback.prototype.stop = function() {
+  if (this.interval) {
+    clearInterval(this.interval);
+  }
+};
+
+/**
  * Animation
  * @constructor
  *
@@ -126,9 +140,7 @@ Animation.prototype.next = function() {
       this.onstart();
     }
 
-    this.normalizedKeyFrames = __.cloneDeep(this.keyFrames);
-    this.normalizedKeyFrames = this.target[Animation.normalize](this.normalizedKeyFrames);
-    this.normalizedKeyFrames = this.normalizeKeyframes(this.normalizedKeyFrames, this.cuePoints);
+    this.normalizeKeyframes();
 
     if (this.reverse) {
       this.currentSpeed *= -1;
@@ -156,7 +168,9 @@ Animation.prototype.pause = function() {
 
   this.emit("animation:pause");
 
-  this.playLoop.stop();
+  if (this.playLoop) {
+    this.playLoop.stop();
+  }
   this.paused = true;
 
   if (this.onpause) {
@@ -177,6 +191,9 @@ Animation.prototype.stop = function() {
   this.emit("animation:stop");
 
   this.segments = [];
+  if (this.playLoop) {
+    this.playLoop.stop();
+  }
   temporal.clear();
 
   if (this.onstop) {
@@ -210,6 +227,65 @@ Animation.prototype.speed = function(speed) {
 };
 
 /**
+ * This function is called in each frame of our animation
+ * Users need not call this. It's automatic
+ */
+
+ Animation.prototype.loopFunction = function(loop) {
+
+  // Find the current timeline progress
+  var progress = this.calculateProgress(loop.calledAt);
+
+  // Find the left and right cuePoints/keyFrames;
+  var indices = this.findIndices(progress);
+
+  // Get tweened value
+  var val = this.tweenedValue(indices, progress);
+
+  // call render function
+  this.target[Animation.render](val);
+
+  // If this animation has been running for more than 5 seconds
+  if (loop.calledAt > this.fallBackTime) {
+    this.fallBackTime = Infinity;
+    if (this.playLoop) {
+      this.playLoop.stop();
+    }
+    this.playLoop = new TemporalFallback(this);
+  }
+
+  // See if we have reached the end of the animation
+  if ((progress === 1 && !this.reverse) || (progress === this.loopback && this.reverse)) {
+
+    if (this.loop || (this.metronomic && !this.reverse)) {
+
+      if (this.onloop) {
+        this.onloop();
+      }
+
+      if (this.metronomic) {
+        this.reverse = this.reverse ? false : true;
+      }
+
+      this.normalizeKeyframes();
+
+      this.progress = this.loopback;
+      this.startTime = Date.now() - this.scaledDuration * this.progress;
+      this.endTime = this.startTime + this.scaledDuration;
+
+    } else {
+
+      this.stop();
+      if (this.oncomplete) {
+        this.oncomplete();
+      }
+      this.next();
+
+    }
+  }
+};
+
+/**
  * play
  *
  * Start a segment
@@ -228,60 +304,17 @@ Animation.prototype.play = function() {
   this.startTime = Date.now() - this.scaledDuration * this.progress;
   this.endTime = this.startTime + this.scaledDuration;
 
+  // If our animation runs for more than 5 seconds switch to setTimeout
+  this.fallBackTime = Date.now() + 5000;
+  this.frameCount = 0;
+
   if (this.fps) {
     this.rate = 1000 / this.fps;
   }
 
   this.rate = this.rate | 0;
 
-  this.playLoop = temporal.loop(this.rate, function(loop) {
-    // Note: "this" is bound to the animation object
-
-    // Find the current timeline progress
-    var progress = this.calculateProgress(loop.calledAt);
-
-    // Find the left and right cuePoints/keyFrames;
-    var indices = this.findIndices(progress);
-
-    // Get tweened value
-    var val = this.tweenedValue(indices, progress);
-
-    // call render function
-    this.target[Animation.render](val);
-
-    // See if we have reached the end of the animation
-    if ((progress === 1 && !this.reverse) || (progress === this.loopback && this.reverse)) {
-
-      if (this.loop || (this.metronomic && !this.reverse)) {
-
-        if (this.onloop) {
-          this.onloop();
-        }
-
-        if (this.metronomic) {
-          this.reverse = this.reverse ? false : true;
-        }
-
-        this.normalizedKeyFrames = __.cloneDeep(this.keyFrames);
-        this.normalizedKeyFrames = this.target[Animation.normalize](this.normalizedKeyFrames);
-        this.normalizedKeyFrames = this.normalizeKeyframes();
-
-        this.progress = this.loopback;
-        this.startTime = Date.now() - this.scaledDuration * this.progress;
-        this.endTime = this.startTime + this.scaledDuration;
-
-      } else {
-
-        this.stop();
-        if (this.oncomplete) {
-          this.oncomplete();
-        }
-        this.next();
-
-      }
-    }
-
-  }.bind(this));
+  this.playLoop = temporal.loop(this.rate, this.loopFunction.bind(this));
 
 };
 
@@ -302,6 +335,7 @@ Animation.prototype.findIndices = function(progress) {
 };
 
 Animation.prototype.calculateProgress = function(calledAt) {
+
   var progress = (calledAt - this.startTime) / this.scaledDuration;
 
   if (progress > 1) {
@@ -317,7 +351,6 @@ Animation.prototype.calculateProgress = function(calledAt) {
   // Ease the timeline
   // to do: When reverse replace inFoo with outFoo and vice versa. skip inOutFoo
   progress = ease[this.easing](progress);
-
   progress = __.constrain(progress, 0, 1);
 
   return progress;
@@ -391,8 +424,11 @@ Animation.prototype.tweenedValue = function(indices, progress) {
 Animation.prototype.normalizeKeyframes = function() {
 
   var previousVal,
-    keyFrameSet = this.normalizedKeyFrames,
+    keyFrameSet = __.cloneDeep(this.keyFrames),
     cuePoints = this.cuePoints;
+
+  // Run through the target's normalization
+  keyFrameSet = this.target[Animation.normalize](keyFrameSet);
 
   // keyFrames can be passed as a single dimensional array if
   // there is just one servo/device. If the first element is not an
@@ -460,7 +496,10 @@ Animation.prototype.normalizeKeyframes = function() {
     }, this);
 
   });
-  return keyFrameSet;
+
+  this.normalizedKeyFrames = keyFrameSet;
+
+  return this;
 };
 
 module.exports = Animation;

--- a/test/animation.js
+++ b/test/animation.js
@@ -122,14 +122,12 @@ exports["Animation"] = {
     var tempSegment = this.segment.single;
     this.animation.enqueue(tempSegment);
 
-    var normalizedKeyFrames = tempSegment.keyFrames;
-    normalizedKeyFrames = this.animation.target["@@normalize"](normalizedKeyFrames);
-    normalizedKeyFrames = this.animation.normalizeKeyframes();
+    this.animation.normalizeKeyframes();
 
-    test.equal(normalizedKeyFrames[0][0].value, 90);
-    test.equal(normalizedKeyFrames[0][1].value, 90);
-    test.equal(normalizedKeyFrames[0][2].value, 45);
-    test.equal(normalizedKeyFrames[0][3].value, 78);
+    test.equal(this.animation.normalizedKeyFrames[0][0].value, 90);
+    test.equal(this.animation.normalizedKeyFrames[0][1].value, 90);
+    test.equal(this.animation.normalizedKeyFrames[0][2].value, 45);
+    test.equal(this.animation.normalizedKeyFrames[0][3].value, 78);
 
     test.done();
   },
@@ -142,22 +140,20 @@ exports["Animation"] = {
 
     this.animation.enqueue(tempSegment);
 
-    var normalizedKeyFrames = tempSegment.keyFrames;
-    normalizedKeyFrames = this.animation.target["@@normalize"](normalizedKeyFrames);
-    normalizedKeyFrames = this.animation.normalizeKeyframes();
+    this.animation.normalizeKeyframes();
 
-    test.equal(normalizedKeyFrames[0][0].value, 90);
-    test.equal(normalizedKeyFrames[0][1].value, 90);
-    test.equal(normalizedKeyFrames[0][2].value, 45);
-    test.equal(normalizedKeyFrames[0][3].value, 78);
-    test.equal(normalizedKeyFrames[1][0].value, 20);
-    test.equal(normalizedKeyFrames[1][1].value, 66);
-    test.equal(normalizedKeyFrames[1][2].value, 180);
-    test.equal(normalizedKeyFrames[1][3].value, 60);
-    test.equal(normalizedKeyFrames[2][0].value, 90);
-    test.equal(normalizedKeyFrames[2][1].value, 120);
-    test.equal(normalizedKeyFrames[2][2].value, 180);
-    test.equal(normalizedKeyFrames[2][3].value, 180);
+    test.equal(this.animation.normalizedKeyFrames[0][0].value, 90);
+    test.equal(this.animation.normalizedKeyFrames[0][1].value, 90);
+    test.equal(this.animation.normalizedKeyFrames[0][2].value, 45);
+    test.equal(this.animation.normalizedKeyFrames[0][3].value, 78);
+    test.equal(this.animation.normalizedKeyFrames[1][0].value, 20);
+    test.equal(this.animation.normalizedKeyFrames[1][1].value, 66);
+    test.equal(this.animation.normalizedKeyFrames[1][2].value, 180);
+    test.equal(this.animation.normalizedKeyFrames[1][3].value, 60);
+    test.equal(this.animation.normalizedKeyFrames[2][0].value, 90);
+    test.equal(this.animation.normalizedKeyFrames[2][1].value, 120);
+    test.equal(this.animation.normalizedKeyFrames[2][2].value, 180);
+    test.equal(this.animation.normalizedKeyFrames[2][3].value, 180);
 
     test.done();
 
@@ -172,16 +168,14 @@ exports["Animation"] = {
 
     this.animation.enqueue(tempSegment);
 
-    var normalizedKeyFrames = tempSegment.keyFrames;
-    normalizedKeyFrames = this.animation.target["@@normalize"](normalizedKeyFrames);
-    normalizedKeyFrames = this.animation.normalizeKeyframes();
+    this.animation.normalizeKeyframes();
 
-    test.equal(normalizedKeyFrames[0][0].value, 90);
-    test.equal(normalizedKeyFrames[0][1].value, 90);
-    test.equal(normalizedKeyFrames[0][2].value, 45);
-    test.equal(normalizedKeyFrames[0][3].value, 78);
-    test.equal(normalizedKeyFrames[1], null);
-    test.equal(normalizedKeyFrames[2], null);
+    test.equal(this.animation.normalizedKeyFrames[0][0].value, 90);
+    test.equal(this.animation.normalizedKeyFrames[0][1].value, 90);
+    test.equal(this.animation.normalizedKeyFrames[0][2].value, 45);
+    test.equal(this.animation.normalizedKeyFrames[0][3].value, 78);
+    test.equal(this.animation.normalizedKeyFrames[1], null);
+    test.equal(this.animation.normalizedKeyFrames[2], null);
 
     test.done();
   },

--- a/test/extended/animation.js
+++ b/test/extended/animation.js
@@ -1,0 +1,129 @@
+var mocks = require("mock-firmata"),
+  MockFirmata = mocks.Firmata,
+  five = require("../../lib/johnny-five.js"),
+  sinon = require("sinon"),
+  board = new five.Board({
+    io: new MockFirmata(),
+    debug: false,
+    repl: false
+  });
+
+exports["Animation"] = {
+  setUp: function(done) {
+    this.servoWrite = sinon.spy(board.io, "servoWrite");
+
+    this.a = new five.Servo({
+      pin: 3,
+      board: board
+    });
+
+    this.b = new five.Servo({
+      pin: 5,
+      board: board,
+      startAt: 20
+    });
+
+    this.c = new five.Servo({
+      pin: 6,
+      board: board
+    });
+
+    this.mockChain = {
+      result: [],
+      "@@render": function(args) {
+        this.result = this.result.concat(args);
+      },
+      "@@normalize": function(keyFrames) {
+        var last = [{degrees: 50}, {degrees: 70}, -20];
+
+        // If user passes null as the first element in keyFrames use current position
+        if (keyFrames[0] === null) {
+          keyFrames[0] = {
+            position: last
+          };
+        }
+
+        return keyFrames;
+      }
+    };
+
+    this.servoArray = new five.Servo.Array([this.a, this.b, this.c]);
+
+    this.segment = {
+      long: {
+        duration: 7000,
+        fps: 10,
+        cuePoints: [0, 0.33, 0.66, 1.0],
+        keyFrames: [
+          [null, false, { degrees: 45 }, 33],
+          [null, 46, { degrees: 180 }, -120],
+          [null, { degrees: 120 }, { step: 60 }]
+        ]
+      }
+    };
+
+    this.proto = [{
+      name: "enqueue"
+    }, {
+      name: "pause"
+    }, {
+      name: "next"
+    }, {
+      name: "stop"
+    }, {
+      name: "play"
+    }, {
+      name: "speed"
+    }];
+
+    this.instance = [{
+      name: "defaultTarget"
+    }, {
+      name: "segments"
+    }];
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.servoWrite.restore();
+    done();
+  },
+
+  shape: function(test) {
+    test.expect(this.proto.length + this.instance.length);
+
+    this.animation = new five.Animation(this.a);
+
+    this.proto.forEach(function(method) {
+      test.equal(typeof this.animation[method.name], "function");
+    }, this);
+
+    this.instance.forEach(function(property) {
+      test.notEqual(typeof this.animation[property.name], "undefined");
+    }, this);
+
+    test.done();
+  },
+
+  longRunning: function(test) {
+
+    this.animation = new five.Animation(this.servoArray);
+
+    test.expect(2);
+
+    this.animation.enqueue(this.segment.long);
+
+    setTimeout(function() {
+      test.ok(this.animation.playLoop.calledAt);
+    }.bind(this), 3000);
+
+    setTimeout(function() {
+      test.ok(this.animation.playLoop.interval);
+      this.animation.stop();
+      test.done();
+    }.bind(this), 6000);
+
+  }
+
+};


### PR DESCRIPTION
temporal uses 100% of the CPU so on long running animations we switch to setInterval instead of temporal (after five seconds). 

Does five seconds seem good? It's completely arbitrary.

Tests look good but I still want to try with hardware so don't land this yet.