### PR TITLE
Fix blinking for the HT16K33 LED controller.

### DIFF
--- a/lib/led/ledcontrol.js
+++ b/lib/led/ledcontrol.js
@@ -488,21 +488,51 @@ Controllers = {
       // TODO allow setup to be configured through opts
       this.each(function(device) {
         this.on(device);
-        this.blink(device, 1);
+        // Turn off blinking during initialization, in case it was left on.
+        this.blink(device, false);
         this.brightness(device, 100);
         this.clear(device);
       });
     },
+
+    /**
+     * Blink the screen.
+     *
+     * @param  {*} addr      Either the index of the device to blink,
+     *                       or the blink value to apply to all devices.
+     * @param  {String} val  The blink value. Either 'slow' (once every 2 seconds),
+     *                       'normal' (once every second), 'fast' (once every 500ms),
+     *                       or false to turn off blinking.
+     * @return {LedControl}  Returns this to allow for chaining.
+     */
     blink: function(addr, val) {
       if (arguments.length === 1) {
         val = addr;
         this.each(function(device) {
-          this.brightness(device, val);
+          this.blink(device, val);
         });
       } else {
-        //var BLINK = 0x80;
-        //this.io.i2cWrite(this.addresses[addr], [BLINK | val]);
-        this.send(addr, this.OP.BLINK, val);
+        var _val = null;
+        // Translate human-readable value to value expected by HT16K33, see datasheet.
+        switch (val) {
+          case false:
+            _val = 0;
+            break;
+          case "slow":
+            _val = 6;
+            break;
+          case "normal":
+            _val = 4;
+            break;
+          case "fast":
+            _val = 2;
+            break;
+        }
+        if (_val == null) {
+          return;
+        }
+        // Add 1 to the opcode to turn blinking functionality on, see datasheet.
+        this.send(addr, this.OP.BLINK | 1, _val);
       }
       return this;
     },

--- a/test/ledcontrol.js
+++ b/test/ledcontrol.js
@@ -440,6 +440,36 @@ exports["LedControl - I2C Matrix"] = {
 
     test.done();
   },
+
+  blink: function(test) {
+    test.expect(1);
+    var expected = [
+      // oscillator on
+      [ 0x70, [ 0x21 ]],
+      // blink off
+      [ 0x70, [ 0x81 ]],
+      // brightness at max
+      [ 0x70, [ 0xEF ]],
+      // clear
+      [ 0x70,[ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]],
+      // slow blink
+      [ 0x70, [ 0x80 | 0x01 | 0x06 ]],
+      // normal blink
+      [ 0x70, [ 0x80 | 0x01 | 0x04 ]],
+      // fast blink
+      [ 0x70, [ 0x80 | 0x01 | 0x02 ]],
+      // no blink
+      [ 0x70, [ 0x80 | 0x01 | 0x00 ]]
+    ];
+    this.lc.blink("slow");
+    this.lc.blink("normal");
+    this.lc.blink("fast");
+    this.lc.blink(false);
+    test.deepEqual(this.i2cWrite.args, expected);
+
+    test.done();
+  },
+
   row: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Fixes #1003. This brings the API in line with the [datasheet's described blink functionality](https://www.adafruit.com/datasheets/ht16K33v110.pdf) (page 10).