### PR TITLE
set version of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "descriptor": "latest",
     "ease-component": "latest",
     "es6-shim": "latest",
-    "lodash": "latest",
+    "lodash": "^3.10.1",
     "nanotimer": "0.3.10",
     "temporal": "latest",
     "array-includes": "latest"


### PR DESCRIPTION
lodash 4.0.0 dropped `pluck` method, so until it can be updated to use `map` drop to 3.10.1