### PR TITLE
Add browser-serialport dependency for NW.js support via Firmata

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -68,9 +68,16 @@ var Serial = {
   attempts: [],
 
   detect: function(callback) {
-    var serialport = IS_TEST_MODE ?
-      require("mock-firmata").SerialPort :
-      require("serialport");
+      
+    var serialport;
+    
+    if (IS_TEST_MODE) {
+      serialport = require("mock-firmata").SerialPort;
+    } else if (parseFloat(process.versions.nw) >= 0.13) {
+      serialport = require("browser-serialport");
+    } else {
+      serialport = require("serialport");
+    }
 
     // Request a list of available ports, from
     // the result set, filter for valid paths

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "array-includes": "latest"
   },
   "optionalDependencies": {
+    "browser-serialport": "latest",
     "firmata": "^0.7.2",
     "serialport": "^2.0.1"
   },


### PR DESCRIPTION
I submitted a very similar and related pull request for the Firmata module (https://github.com/jgautier/firmata/pull/108). If both PRs are merged in, NW.js v0.13 and Johnny-Five would work together right out of the box. The huge gain is that it would no longer be necessary to custom-compile node-serialport for NW.js (which is prohibitively complicated for beginners).

With the small changes I'm suggesting in this PR and the one for Firmata, I was able to successfully use Arduino + browser-serialport + Firmata + Johnny-Five + NW.js. This is an amazingly powerful combination for physical computing and robotics. 