### PR TITLE
Add support for CSS color names to RGB.color()

### DIFF
--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -311,18 +311,7 @@ RGB.prototype.color = function(red, green, blue) {
         
       } else {
         // color name
-        input = converter.keyword2rgb(input.toLowerCase());
-
-        // we are unable to match the name
-        if (typeof input === "undefined") {
-          throw new Error("Led.RGB.color: invalid color (" + red + ")");
-        }
-
-        update = {
-          red: input[0],
-          green: input[1],
-          blue: input[2]
-        };
+        return this.color(converter.keyword2rgb(input.toLowerCase()));
       }
     }
   } else {

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -1,6 +1,7 @@
 var Board = require("../board.js");
 var Expander = require("../../lib/expander");
 var __ = require("../fn.js");
+var converter = require("color-convert");
 
 var priv = new Map();
 
@@ -245,7 +246,7 @@ RGB.colors = ["red", "green", "blue"];
 /**
 * color
 *
-* @param  {String} color Hexadecimal color string
+* @param  {String} color Hexadecimal color string or CSS color name
 * @param  {Array} color Array of color values
 * @param  {Object} color object {red, green, blue}
 *
@@ -292,21 +293,37 @@ RGB.prototype.color = function(red, green, blue) {
           blue: input.blue
         };
     } else if (typeof input === "string") {
-      // color("#ffffff")
-      if (input.length === 7 && input[0] === "#") {
-        input = input.slice(1);
-      }
 
-      if (!input.match(/^[0-9A-Fa-f]{6}$/)) {
-        throw new Error("Led.RGB.color: invalid color (#" + input + ")");
-      }
+      // color("#ffffff") or color("ffffff")
+      if (input.match(/^#?[0-9A-Fa-f]{6}$/)) {
 
-      // color("ffffff")
-      update = {
-        red: parseInt(input.slice(0, 2), 16),
-        green: parseInt(input.slice(2, 4), 16),
-        blue: parseInt(input.slice(4, 6), 16)
-      };
+        // remove the leading # if there is one
+        if (input.length === 7 && input[0] === "#") {
+          input = input.slice(1);
+        }
+
+         update = {
+          red: parseInt(input.slice(0, 2), 16),
+          green: parseInt(input.slice(2, 4), 16),
+          blue: parseInt(input.slice(4, 6), 16)
+        };
+
+        
+      } else {
+        // color name
+        input = converter.keyword2rgb(input.toLowerCase());
+
+        // we are unable to match the name
+        if (typeof input === "undefined"){
+          throw new Error("Led.RGB.color: invalid color (" + red + ")");
+        }
+
+        update = {
+          red: input[0],
+          green: input[1],
+          blue: input[2]
+        };
+      }
     }
   } else {
     // color(Byte, Byte, Byte)

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -314,7 +314,7 @@ RGB.prototype.color = function(red, green, blue) {
         input = converter.keyword2rgb(input.toLowerCase());
 
         // we are unable to match the name
-        if (typeof input === "undefined"){
+        if (typeof input === "undefined") {
           throw new Error("Led.RGB.color: invalid color (" + red + ")");
         }
 

--- a/test/led.js
+++ b/test/led.js
@@ -682,7 +682,7 @@ exports["Led.RGB"] = {
   color: function(test) {
     var rgb = this.rgb;
 
-    test.expect(30);
+    test.expect(36);
 
     // returns this
     test.equal(this.rgb.color("#000000"), this.rgb);
@@ -703,6 +703,18 @@ exports["Led.RGB"] = {
     this.rgb.color("0000ff");
     test.ok(this.write.calledOnce);
     test.ok(this.write.calledWith({ red: 0x00, green: 0x00, blue: 0xff }));
+    this.write.reset();
+
+    // name
+    this.rgb.color("PapayaWhip");
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 0xff, green: 0xef, blue: 0xd5 }));
+    this.write.reset();
+
+    // lowercase names
+    this.rgb.color("papayawhip");
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({ red: 0xff, green: 0xef, blue: 0xd5 }));
     this.write.reset();
 
     // three arguments
@@ -752,6 +764,14 @@ exports["Led.RGB"] = {
     });
     test.throws(function() {
       rgb.color("#ffffffff");
+    });
+
+    // bad color names
+    test.throws(function() {
+      rgb.color("not a real color");
+    });
+    test.throws(function() {
+      rgb.color("#papayawhip");
     });
 
     // missing/null/undefined param


### PR DESCRIPTION
After  a discussion with @rwaldron at the recent Nodebots NYC meetup, I wanted to add support for CSS color names when setting the color of an RGB LED.  As it turns out, one of the already available dependencies, `color-convert`, can do that for us.  This could be useful for people not comfortable with hex color codes.  

Example usage:
```
 // Initialize the RGB LED
  var led = new five.Led.RGB({
    pins: {
      red: 6,
      green: 5,
      blue: 3
    }
  });

  // Turn it on and set the initial color
  led.on();
  led.color("green");
```