### PR TITLE
Mix in controller properties for `Piezo`

### DIFF
--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -8,7 +8,7 @@ var Controllers = {
 
   DEFAULT: {
     initialize: {
-      value: function(opts) {
+      value: function() {
         this.io.pinMode(this.pin, this.io.MODES.OUTPUT);
       }
     }
@@ -25,6 +25,8 @@ function Piezo(opts) {
   Board.Component.call(
     this, opts = Board.Options(opts)
   );
+
+  var controller;
 
   if (opts.controller && typeof opts.controller === "string") {
     controller = Controllers[opts.controller.toUpperCase()];
@@ -55,7 +57,7 @@ function Piezo(opts) {
   });
 
   if (typeof this.initialize === "function") {
-    this.initialize(opts);
+    this.initialize();
   }
 }
 

--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -5,11 +5,60 @@ var priv = new Map();
 
 
 var Controllers = {
-
+  /**
+   * Timer-based tone generator using digital high/low piezo.
+   */
   DEFAULT: {
     initialize: {
+      writable: true,
       value: function() {
         this.io.pinMode(this.pin, this.io.MODES.OUTPUT);
+      }
+    },
+    tone: {
+      writable: true,
+      value: function(tone, duration) {
+        if (isNaN(tone) || isNaN(duration)) {
+          // Very Bad Things happen if one tries to play a NaN tone
+          throw new Error(
+              "Piezo.tone: invalid tone or duration"
+          );
+        }
+
+        clearTimer.call(this);
+
+        var timer = this.timer = new Timer();
+        var value = 1;
+
+        timer.setInterval(function() {
+          value = value === 1 ? 0 : 1;
+          this.io.digitalWrite(this.pin, value);
+
+          if ((timer.difTime / 1000000) > duration) {
+            clearTimer.call(this);
+          }
+        }.bind(this), null, tone + "u", function() {});
+
+        return this;
+      }
+    },
+    frequency: {
+      writable: true,
+      value: function(frequency, duration) {
+        var period = 1 / frequency;
+        var duty = period / 2;
+        var tone = Math.round(duty * 1000000);
+
+        return this.tone(tone, duration);
+      }
+    },
+    noTone: {
+      writable: true,
+      value: function() {
+        this.io.digitalWrite(this.pin, 0);
+        clearTimer.call(this);
+
+        return this;
       }
     }
   }
@@ -37,6 +86,8 @@ function Piezo(opts) {
   if (controller == null) {
     controller = Controllers.DEFAULT;
   }
+
+  Object.defineProperties(this, controller);
 
   Board.Controller.call(this, controller, opts);
 
@@ -258,39 +309,6 @@ Piezo.prototype.note = function(note, duration) {
   return this.tone(tone, duration);
 };
 
-Piezo.prototype.tone = function(tone, duration) {
-  if (isNaN(tone) || isNaN(duration)) {
-    // Very Bad Things happen if one tries to play a NaN tone
-    throw new Error(
-      "Piezo.tone: invalid tone or duration"
-    );
-  }
-
-  clearTimer.call(this);
-
-  var timer = this.timer = new Timer();
-  var value = 1;
-
-  timer.setInterval(function() {
-    value = value === 1 ? 0 : 1;
-    this.io.digitalWrite(this.pin, value);
-
-    if ((timer.difTime / 1000000) > duration) {
-      clearTimer.call(this);
-    }
-  }.bind(this), null, tone + "u", function() {});
-
-  return this;
-};
-
-Piezo.prototype.frequency = function(frequency, duration) {
-  var period = 1 / frequency;
-  var duty = period / 2;
-  var tone = Math.round(duty * 1000000);
-
-  return this.tone(tone, duration);
-};
-
 function stringToSong(stringSong, beats) {
   beats = beats || 1;
   var notes = stringSong.match(/\S+/g);
@@ -365,14 +383,9 @@ Piezo.prototype.play = function(tune, callback) {
   return this;
 };
 
-Piezo.prototype.noTone = function() {
-  this.io.digitalWrite(this.pin, 0);
-  clearTimer.call(this);
-
-  return this;
+Piezo.prototype.off = function() {
+  return this.noTone();
 };
-
-Piezo.prototype.off = Piezo.prototype.noTone;
 
 Piezo.prototype.stop = function() {
   var state = priv.get(this);

--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -1,8 +1,19 @@
+var IS_TEST_MODE = !!process.env.IS_TEST_MODE;
 var Board = require("./board"),
   Timer = require("nanotimer");
 
 var priv = new Map();
 
+var MICROSECONDS_PER_SECOND = 1000000;
+
+function clearTimer() {
+  if (!this.timer) {
+    return;
+  }
+
+  this.timer.clearInterval();
+  delete this.timer;
+}
 
 var Controllers = {
   /**
@@ -40,16 +51,6 @@ var Controllers = {
         }.bind(this), null, tone + "u", function() {});
 
         return this;
-      }
-    },
-    frequency: {
-      writable: true,
-      value: function(frequency, duration) {
-        var period = 1 / frequency;
-        var duty = period / 2;
-        var tone = Math.round(duty * 1000000);
-
-        return this.tone(tone, duration);
       }
     },
     noTone: {
@@ -224,15 +225,6 @@ Piezo.Notes = {
   "b8": 7902
 };
 
-function clearTimer() {
-  if (!this.timer) {
-    return;
-  }
-
-  this.timer.clearInterval();
-  delete this.timer;
-}
-
 /**
  * Get the tone from the current note. note
  * could be an int, string, array or null.
@@ -308,6 +300,40 @@ Piezo.prototype.note = function(note, duration) {
 
   return this.tone(tone, duration);
 };
+
+function throwNeedsToneFrequencyError() {
+  throw new Error(
+      "Piezo.tone: Controller must define either frequency or tone function."
+  );
+}
+
+Piezo.prototype.tone = function(tone, duration) {
+  if (this.frequency === Piezo.prototype.frequency) {
+    throwNeedsToneFrequencyError();
+  }
+
+  return this.frequency(toneToFrequency(tone), duration);
+};
+
+Piezo.prototype.frequency = function(frequency, duration) {
+  if (this.tone === Piezo.prototype.tone) {
+    throwNeedsToneFrequencyError();
+  }
+
+  return this.tone(frequencyToTone(frequency), duration);
+};
+
+function toneToFrequency(toneMicroseconds) {
+  var toneSeconds = toneMicroseconds / MICROSECONDS_PER_SECOND;
+  var period = toneSeconds * 2;
+  return Math.round(1 / period);
+}
+
+function frequencyToTone(frequency) {
+  var period = 1 / frequency;
+  var duty = period / 2;
+  return Math.round(duty * MICROSECONDS_PER_SECOND);
+}
 
 function stringToSong(stringSong, beats) {
   beats = beats || 1;
@@ -396,5 +422,10 @@ Piezo.prototype.stop = function() {
 
   return this;
 };
+
+if (IS_TEST_MODE) {
+  Piezo.frequencyToTone = frequencyToTone;
+  Piezo.toneToFrequency = toneToFrequency;
+}
 
 module.exports = Piezo;

--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -3,17 +3,40 @@ var Board = require("./board"),
 
 var priv = new Map();
 
+
+var Controllers = {
+
+  DEFAULT: {
+    initialize: {
+      value: function(opts) {
+        this.io.pinMode(this.pin, this.io.MODES.OUTPUT);
+      }
+    }
+  }
+
+};
+
 function Piezo(opts) {
+
+  if (!(this instanceof Piezo)) {
+    return new Piezo(opts);
+  }
 
   Board.Component.call(
     this, opts = Board.Options(opts)
   );
 
-  // Hardware instance properties
-  this.mode = this.io.MODES.OUTPUT;
-  this.pin = opts.pin || 3;
+  if (opts.controller && typeof opts.controller === "string") {
+    controller = Controllers[opts.controller.toUpperCase()];
+  } else {
+    controller = opts.controller;
+  }
 
-  this.io.pinMode(this.pin, this.mode);
+  if (controller == null) {
+    controller = Controllers.DEFAULT;
+  }
+
+  Board.Controller.call(this, controller, opts);
 
   // Piezo instance properties
   var state = {
@@ -31,8 +54,8 @@ function Piezo(opts) {
     }
   });
 
-  if (opts.controller) {
-    Object.defineProperties(this, opts.controller);
+  if (typeof this.initialize === "function") {
+    this.initialize(opts);
   }
 }
 

--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -30,6 +30,10 @@ function Piezo(opts) {
       }
     }
   });
+
+  if (opts.controller) {
+    Object.defineProperties(this, opts.controller);
+  }
 }
 
 // These notes are rounded up at .5 otherwise down.

--- a/test/piezo.js
+++ b/test/piezo.js
@@ -310,6 +310,15 @@ exports["Piezo"] = {
     test.done();
   },
 
+  frequencyToneConversion: function(test) {
+    test.expect(2);
+
+    test.equal(Piezo.toneToFrequency(1136), 440);
+    test.equal(Piezo.frequencyToTone(440), 1136);
+
+    test.done();
+  },
+
   noTone: function(test) {
     test.expect(2);
 
@@ -436,4 +445,74 @@ exports["Piezo"] = {
 
     this.clock.tick(100);
   },
+};
+
+exports["PiezoWithCustomControllers"] = {
+
+  setUp: function (done) {
+    this.board = newBoard();
+    this.clock = sinon.useFakeTimers();
+
+    this.digitalWrite = sinon.spy(MockFirmata.prototype, "digitalWrite");
+    done();
+  },
+
+  canRedefineFrequencyWithController: function (test) {
+    test.expect(2);
+
+    var TestController = {
+      frequency: {
+        writable: true,
+        value: function (frequency, duration) {
+          test.equal(frequency, 440);
+        }
+      }
+    };
+    var piezo = new Piezo({pin: 3, controller: TestController});
+    piezo.frequency(440, 1000);
+    piezo.tone(1136, 1000);
+
+    test.done();
+  },
+
+  canRedefineToneWithController: function (test) {
+    test.expect(2);
+
+    var TestController = {
+      tone: {
+        writable: true,
+        value: function (tone, duration) {
+          test.equal(tone, 1136);
+        }
+      }
+    };
+    var piezo = new Piezo({pin: 3, controller: TestController});
+    piezo.frequency(440, 1000);
+    piezo.tone(1136, 1000);
+
+    test.done();
+  },
+
+  throwsIfNeitherToneNorFrequency: function (test) {
+    test.expect(2);
+
+    var piezo = new Piezo({pin: 3, controller: {}});
+
+    test.throws(function() {
+      piezo.frequency(440, 1000);
+    }.bind(this));
+
+    test.throws(function() {
+      piezo.tone(1136, 1000);
+    }.bind(this));
+
+    test.done();
+  },
+
+  tearDown: function(done) {
+    Board.purge();
+    restore(this);
+    done();
+  }
+
 };

--- a/test/piezo.js
+++ b/test/piezo.js
@@ -451,9 +451,6 @@ exports["PiezoWithCustomControllers"] = {
 
   setUp: function (done) {
     this.board = newBoard();
-    this.clock = sinon.useFakeTimers();
-
-    this.digitalWrite = sinon.spy(MockFirmata.prototype, "digitalWrite");
     done();
   },
 
@@ -469,7 +466,11 @@ exports["PiezoWithCustomControllers"] = {
         }
       }
     };
-    var piezo = new Piezo({pin: 3, controller: TestController});
+    var piezo = new Piezo({
+      pin: 3,
+      controller: TestController,
+      board: this.board
+    });
     piezo.frequency(440, 1000);
     piezo.tone(1136, 1000);
 
@@ -488,7 +489,11 @@ exports["PiezoWithCustomControllers"] = {
         }
       }
     };
-    var piezo = new Piezo({pin: 3, controller: TestController});
+    var piezo = new Piezo({
+      pin: 3,
+      controller: TestController,
+      board: this.board
+    });
     piezo.frequency(440, 1000);
     piezo.tone(1136, 1000);
 
@@ -498,7 +503,11 @@ exports["PiezoWithCustomControllers"] = {
   throwsIfNeitherToneNorFrequency: function (test) {
     test.expect(2);
 
-    var piezo = new Piezo({pin: 3, controller: {}});
+    var piezo = new Piezo({
+      pin: 3,
+      controller: {},
+      board: this.board
+    });
 
     test.throws(function() {
       piezo.frequency(440, 1000);

--- a/test/piezo.js
+++ b/test/piezo.js
@@ -449,18 +449,18 @@ exports["Piezo"] = {
 
 exports["PiezoWithCustomControllers"] = {
 
-  setUp: function (done) {
+  setUp: function(done) {
     this.board = newBoard();
     done();
   },
 
-  canRedefineFrequencyWithController: function (test) {
+  canRedefineFrequencyWithController: function(test) {
     test.expect(4);
 
     var TestController = {
       frequency: {
         writable: true,
-        value: function (frequency, duration) {
+        value: function(frequency, duration) {
           test.equal(frequency, 440);
           test.equal(duration, 1000);
         }
@@ -477,13 +477,13 @@ exports["PiezoWithCustomControllers"] = {
     test.done();
   },
 
-  canRedefineToneWithController: function (test) {
+  canRedefineToneWithController: function(test) {
     test.expect(4);
 
     var TestController = {
       tone: {
         writable: true,
-        value: function (tone, duration) {
+        value: function(tone, duration) {
           test.equal(tone, 1136);
           test.equal(duration, 1000);
         }
@@ -500,7 +500,7 @@ exports["PiezoWithCustomControllers"] = {
     test.done();
   },
 
-  throwsIfNeitherToneNorFrequency: function (test) {
+  throwsIfNeitherToneNorFrequency: function(test) {
     test.expect(2);
 
     var piezo = new Piezo({

--- a/test/piezo.js
+++ b/test/piezo.js
@@ -458,13 +458,14 @@ exports["PiezoWithCustomControllers"] = {
   },
 
   canRedefineFrequencyWithController: function (test) {
-    test.expect(2);
+    test.expect(4);
 
     var TestController = {
       frequency: {
         writable: true,
         value: function (frequency, duration) {
           test.equal(frequency, 440);
+          test.equal(duration, 1000);
         }
       }
     };
@@ -476,13 +477,14 @@ exports["PiezoWithCustomControllers"] = {
   },
 
   canRedefineToneWithController: function (test) {
-    test.expect(2);
+    test.expect(4);
 
     var TestController = {
       tone: {
         writable: true,
         value: function (tone, duration) {
           test.equal(tone, 1136);
+          test.equal(duration, 1000);
         }
       }
     };

--- a/test/piezo.js
+++ b/test/piezo.js
@@ -520,6 +520,27 @@ exports["PiezoWithCustomControllers"] = {
     test.done();
   },
 
+  canRedefineNoTone: function(test) {
+    test.expect(2);
+
+    var piezo = new Piezo({
+      pin: 3,
+      controller: {
+        noTone: {
+          value: function() {
+            test.ok(1);
+          }
+        }
+      },
+      board: this.board
+    });
+
+    piezo.off();
+    piezo.noTone();
+
+    test.done();
+  },
+
   tearDown: function(done) {
     Board.purge();
     restore(this);


### PR DESCRIPTION
Allow for custom piezo controller following [led controller](https://github.com/rwaldron/johnny-five/blob/master/lib/led/led.js#L142) property mix-in pattern. Mostly to support overriding of `setTone`/`noTone` per https://github.com/rwaldron/playground-io/pull/1, but may be of interest for #815.

@rwaldron let me know if you'd prefer I stub out more or use a different approach for mixing in, could do any of:

1. Stub out default controller behavior (add a `Controllers` map with an empty `DEFAULT`)
1. Move default piezo tone/no-tone behavior into the `DEFAULT` controller
1. Use some sort of different controller overriding pattern

TODO:

- [x] 1, 2, 3 above
- [x] Write test covering controller behavior