### PR TITLE
added node-open-pilot project

### DIFF
--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -135,6 +135,7 @@ To interactively navigate the examples, visit the [Johnny-Five examples](http://
 #### [Joystick Controlled Claw](http://jsfiddle.net/rwaldron/6ZXFe/show/light/)
 #### [Robot Claw](http://jsfiddle.net/rwaldron/CFSZJ/show/light/)
 #### [Joystick, Motor & Led](http://jsfiddle.net/rwaldron/gADSz/show/light/)
+#### [Build you own drone](http://github.com/darioodiaz/node-open-pilot/)
 
 
 


### PR DESCRIPTION
Node Open Pilot is an opensource software and openhardware project yo build your own drone using a firmata-board compatible and johnny-five