### PR TITLE
Default custom property to object literal instead of null

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -798,7 +798,7 @@ Board.Component = function(opts, componentOpts) {
 
   // Component/Module instance properties
   this.id = opts.id || Board.uid();
-  this.custom = opts.custom || null;
+  this.custom = opts.custom || {};
 
   var originalPins;
 

--- a/test/sensor.js
+++ b/test/sensor.js
@@ -74,7 +74,7 @@ exports["Sensor - Analog"] = {
     // excluding the 'external' references for the board and io properties.
     this.defShape = {
       id: this.sensor.id,
-      custom: null,
+      custom: {},
       mode: this.sensor.io.MODES.ANALOG,
       freq: 25,
       range: [0, 1023],


### PR DESCRIPTION
Currently, adding custom properties like that is not supported:
```
mydevice.custom.foo = "bar";
```
and it fails with ```TypeError: Cannot set property 'foo' of null```

Changing default value from ```null``` to a real object would fix this.