### PR TITLE
Pin aliasing

### DIFF
--- a/lib/board.options.js
+++ b/lib/board.options.js
@@ -4,16 +4,17 @@
 
 var MISO = "miso";
 var MOSI = "mosi";
-var SCLK = "sclk";
+var CLK = "clk";
 var SS = "ss";
 
 // jshint unused:false
 var aliases = {
 
-  // SCLK
-  clk: SCLK,
-  clock: SCLK,
-  sclk: SCLK,
+  // CLK
+  clk: CLK,
+  clock: CLK,
+  sclk: CLK,
+  sck: CLK,
 
   // MISO
   somi: MISO,
@@ -29,6 +30,7 @@ var aliases = {
   sdi: MOSI,
   data: MOSI,
   di: MOSI,
+  dn: MOSI,
   din: MOSI,
   si: MOSI,
   mtst: MOSI,
@@ -74,7 +76,15 @@ function Options(arg) {
   } else {
     opts = arg;
 
+    if (opts && opts.pins != null) {
+      Object.keys(opts.pins).forEach(function(key) {
+        var alias = aliases[key.toLowerCase()];
 
+        if (alias) {
+          opts.pins[alias] = opts.pins[key];
+        }
+      });
+    }
     // @Nick, this is where you want to focus.
     // Anytime this path is taken, the constructor
     // received an object. If the object contains

--- a/lib/led/ledcontrol.js
+++ b/lib/led/ledcontrol.js
@@ -49,10 +49,10 @@ var priv = new Map(),
  * @param {Number}  [opts.devices]    The number of connected LED devices.
  * @param {Array}   [opts.addresses]  I2C addresses.
  * @param {*}       opts.pins         The digital pin numbers that connect to
- *                                    data, clock, and cs connections on the controller device.
+ *                                    mosi, clk, and ss connections on the controller device.
  *                                    Only for use with the default controller.
- *                                    Accepts either an object ({data, clock, cs})
- *                                    or an array ([data, clock, cs]).
+ *                                    Accepts either an object ({mosi, clk, ss})
+ *                                    or an array ([mosi, clk, ss]).
  * @param {*}       [opts.dims]       Dimensions of the LED screen.
  *                                    Only for use with the HT16K33 controller.
  * @param {Boolean} [opts.isBicolor]  Whether the LED screen is bicolor.
@@ -774,12 +774,7 @@ Controllers = {
     OP: {},
     initialize: function(opts) {
 
-      this.pins = {
-        data: opts.pins.data,
-        clock: opts.pins.clock,
-        cs: opts.pins.cs || opts.pins.latch
-      };
-      ["data", "clock", "cs"].forEach(function(pin) {
+      ["mosi", "clk", "ss"].forEach(function(pin) {
         this.io.pinMode(this.pins[pin], this.io.MODES.OUTPUT);
       }, this);
       // NOTE: Currently unused, these will form
@@ -788,7 +783,6 @@ Controllers = {
       // var keys = Object.keys(setup);
 
       // digit indexes ordered right to left.
-      this.digitOrder = -1;
       this.digitOrder = -1;
 
       for (var device = 0; device < this.devices; device++) {
@@ -811,9 +805,9 @@ Controllers = {
 
             var lc = new five.LedControl({
               pins: {
-                data: 2,
-                clock: 3,
-                cs: 4
+                mosi: 2,
+                clk: 3,
+                ss: 4
               },
               setup: {
                 DECODING: 0,
@@ -979,13 +973,13 @@ Controllers = {
         spiData[offset + 1] = opcode;
         spiData[offset] = data;
 
-        this.io.digitalWrite(this.pins.cs, this.io.LOW);
+        this.io.digitalWrite(this.pins.ss, this.io.LOW);
 
         for (var j = maxBytes; j > 0; j--) {
-          this.board.shiftOut(this.pins.data, this.pins.clock, spiData[j - 1]);
+          this.board.shiftOut(this.pins.mosi, this.pins.clk, spiData[j - 1]);
         }
 
-        this.io.digitalWrite(this.pins.cs, this.io.HIGH);
+        this.io.digitalWrite(this.pins.ss, this.io.HIGH);
       }
 
       return this;

--- a/lib/led/ledcontrol.js
+++ b/lib/led/ledcontrol.js
@@ -772,7 +772,7 @@ Controllers = {
 
   DEFAULT: {
     OP: {},
-    initialize: function(opts) {
+    initialize: function() {
 
       ["mosi", "clk", "ss"].forEach(function(pin) {
         this.io.pinMode(this.pins[pin], this.io.MODES.OUTPUT);

--- a/lib/shiftregister.js
+++ b/lib/shiftregister.js
@@ -133,7 +133,7 @@ ShiftRegister.prototype.send = function(value) {
         arg = encoded.cathode[index];
       }
     }
-    this.board.shiftOut(this.pins.data, this.pins.clock, true, arg);
+    this.board.shiftOut(this.pins.mosi, this.pins.clk, true, arg);
   }, this);
 
   // close latch to commit bits into register.
@@ -157,9 +157,9 @@ ShiftRegister.prototype.reset = function() {
   if (this.pins.reset === null) {
     throw new Error("ShiftRegister was not initialized with a reset pin");
   }
-  this.io.digitalWrite(this.pins.clock, this.io.LOW);
+  this.io.digitalWrite(this.pins.clk, this.io.LOW);
   this.io.digitalWrite(this.pins.reset, this.io.LOW);
-  this.io.digitalWrite(this.pins.clock, this.io.HIGH);
+  this.io.digitalWrite(this.pins.clk, this.io.HIGH);
   this.io.digitalWrite(this.pins.reset, this.io.HIGH);
 
   return this;

--- a/test/options.js
+++ b/test/options.js
@@ -83,7 +83,7 @@ exports["aliasing"] = {
       pins: {
         data: 1
       }
-    })
+    });
 
     test.equal(result.pins.mosi, 1);
 
@@ -95,7 +95,7 @@ exports["aliasing"] = {
       pins: {
         dout: 1
       }
-    })
+    });
 
     test.equal(result.pins.miso, 1);
 
@@ -107,7 +107,7 @@ exports["aliasing"] = {
       pins: {
         clock: 1
       }
-    })
+    });
 
     test.equal(result.pins.clk, 1);
 
@@ -119,7 +119,7 @@ exports["aliasing"] = {
       pins: {
         cs: 1
       }
-    })
+    });
 
     test.equal(result.pins.ss, 1);
 

--- a/test/options.js
+++ b/test/options.js
@@ -76,3 +76,53 @@ exports["static"] = {
     test.done();
   }
 };
+
+exports["aliasing"] = {
+  mosi: function(test) {
+    var result = new Options({
+      pins: {
+        data: 1
+      }
+    })
+
+    test.equal(result.pins.mosi, 1);
+
+    test.done();
+  },
+
+  miso: function(test) {
+    var result = new Options({
+      pins: {
+        dout: 1
+      }
+    })
+
+    test.equal(result.pins.miso, 1);
+
+    test.done();
+  },
+
+  clk: function(test) {
+    var result = new Options({
+      pins: {
+        clock: 1
+      }
+    })
+
+    test.equal(result.pins.clk, 1);
+
+    test.done();
+  },
+
+  ss: function(test) {
+    var result = new Options({
+      pins: {
+        cs: 1
+      }
+    })
+
+    test.equal(result.pins.ss, 1);
+
+    test.done();
+  }
+};

--- a/test/shiftregister.js
+++ b/test/shiftregister.js
@@ -46,9 +46,9 @@ exports["ShiftRegister - Common Cathode (default)"] = {
     }];
 
     this.pins = [{
-      name: "data"
+      name: "mosi"
     }, {
-      name: "clock"
+      name: "clk"
     }, {
       name: "latch"
     }, {
@@ -90,8 +90,8 @@ exports["ShiftRegister - Common Cathode (default)"] = {
       board: this.board
     });
 
-    test.equal(this.shiftRegister.pins.data, 2);
-    test.equal(this.shiftRegister.pins.clock, 3);
+    test.equal(this.shiftRegister.pins.mosi, 2);
+    test.equal(this.shiftRegister.pins.clk, 3);
     test.equal(this.shiftRegister.pins.latch, 4);
 
     this.shiftRegister = new ShiftRegister({
@@ -99,8 +99,8 @@ exports["ShiftRegister - Common Cathode (default)"] = {
       board: this.board
     });
 
-    test.equal(this.shiftRegister.pins.data, 6);
-    test.equal(this.shiftRegister.pins.clock, 7);
+    test.equal(this.shiftRegister.pins.mosi, 6);
+    test.equal(this.shiftRegister.pins.clk, 7);
     test.equal(this.shiftRegister.pins.latch, 8);
     test.equal(this.shiftRegister.pins.reset, 9);
 
@@ -112,14 +112,14 @@ exports["ShiftRegister - Common Cathode (default)"] = {
 
     this.shiftRegister = new ShiftRegister([2, 3, 4]);
 
-    test.equal(this.shiftRegister.pins.data, 2);
-    test.equal(this.shiftRegister.pins.clock, 3);
+    test.equal(this.shiftRegister.pins.mosi, 2);
+    test.equal(this.shiftRegister.pins.clk, 3);
     test.equal(this.shiftRegister.pins.latch, 4);
 
     this.shiftRegister = new ShiftRegister([6, 7, 8, 9]);
 
-    test.equal(this.shiftRegister.pins.data, 6);
-    test.equal(this.shiftRegister.pins.clock, 7);
+    test.equal(this.shiftRegister.pins.mosi, 6);
+    test.equal(this.shiftRegister.pins.clk, 7);
     test.equal(this.shiftRegister.pins.latch, 8);
     test.equal(this.shiftRegister.pins.reset, 9);
 
@@ -349,8 +349,8 @@ exports["ShiftRegister - Common Anode"] = {
       board: this.board
     });
 
-    test.equal(this.shiftRegister.pins.data, 2);
-    test.equal(this.shiftRegister.pins.clock, 3);
+    test.equal(this.shiftRegister.pins.mosi, 2);
+    test.equal(this.shiftRegister.pins.clk, 3);
     test.equal(this.shiftRegister.pins.latch, 4);
 
     this.shiftRegister = new ShiftRegister({
@@ -359,8 +359,8 @@ exports["ShiftRegister - Common Anode"] = {
       board: this.board
     });
 
-    test.equal(this.shiftRegister.pins.data, 6);
-    test.equal(this.shiftRegister.pins.clock, 7);
+    test.equal(this.shiftRegister.pins.mosi, 6);
+    test.equal(this.shiftRegister.pins.clk, 7);
     test.equal(this.shiftRegister.pins.latch, 8);
     test.equal(this.shiftRegister.pins.reset, 9);
 


### PR DESCRIPTION
Worked on this a bit with @rwaldron.

The labels for pins on development boards don't always match up with the property names for the pins object that is passed into the constructor for various classes, i.e. [the `Led.Digits` class usage](http://johnny-five.io/api/led.digits/#usage). Because of the non-standard naming for these pin labels, it's difficult for folks who don't know how their board's pins match up with the Johnny-Five API. 

This PR allows any of the known SPI aliases for `miso`, `clk`, `ss`, `mosi` to be used in for the properties of that pins object. 

**Concerns:**
I'm not sure how to reflect this in the various docs that show `data`, `clock`, and `cs` being used for those properties. 

This will also break any uses of `ShiftRegister.pins`. 
