### PR TITLE
animation-fixes

### DIFF
--- a/lib/animation.js
+++ b/lib/animation.js
@@ -10,7 +10,13 @@ var ease = require("ease-component"),
   __ = require("./fn"),
   temporal;
 
-Animation.DEFAULTS = {
+/**
+ * Every property ever used on an animation segment
+ * MUST be listed here, otherwise properties will
+ * persist across segments. This default object is
+ * primarily for resetting state.
+ */
+ Animation.DEFAULTS = {
   cuePoints: [0, 1],
   duration: 1000,
   easing: "linear",
@@ -29,6 +35,14 @@ Animation.DEFAULTS = {
   oncomplete: null,
   onloop: null
 };
+
+/**
+ * The max time we want to allow a temporal animation segment to run.
+ * When running, temporal can push CPU utilization to 100%. When this
+ * time (in ms) is reached we will fall back to setInterval which is less
+ * accurate (by nanoseconds) but perfectly serviceable.
+ **/
+var temporalTTL = 5000;
 
 /**
  * Placeholders for Symbol
@@ -140,6 +154,8 @@ Animation.prototype.next = function() {
 
     Object.assign(this, this.segments.shift());
 
+    this.paused = this.currentSpeed === 0 ? true : false;
+
     if (this.onstart) {
       this.onstart();
     }
@@ -225,6 +241,10 @@ Animation.prototype.speed = function(speed) {
     this.scaledDuration = this.duration / Math.abs(this.currentSpeed);
     this.startTime = Date.now() - this.scaledDuration * this.progress;
     this.endTime = this.startTime + this.scaledDuration;
+
+    if (!this.paused) {
+      this.play();
+    }
     return this;
   }
 };
@@ -248,7 +268,10 @@ Animation.prototype.loopFunction = function(loop) {
   // call render function
   this.target[Animation.render](val);
 
-  // If this animation has been running for more than 5 seconds
+  /**
+   * If this animation has been running in temporal for too long
+   * fall back to using setInterval so we don't melt the user's CPU
+   **/
   if (loop.calledAt > this.fallBackTime) {
     this.fallBackTime = Infinity;
     if (this.playLoop) {
@@ -279,10 +302,14 @@ Animation.prototype.loopFunction = function(loop) {
     } else {
 
       this.stop();
+
       if (this.oncomplete) {
-        this.oncomplete();
+        process.nextTick(this.oncomplete.bind(this));
       }
-      this.next();
+
+      if (this.segments.length > 0) {
+        this.next();
+      }
 
     }
   }
@@ -295,6 +322,7 @@ Animation.prototype.loopFunction = function(loop) {
  */
 
 Animation.prototype.play = function() {
+
   var now = Date.now();
 
   if (this.playLoop) {
@@ -309,7 +337,7 @@ Animation.prototype.play = function() {
   this.endTime = this.startTime + this.scaledDuration;
 
   // If our animation runs for more than 5 seconds switch to setTimeout
-  this.fallBackTime = now + 5000;
+  this.fallBackTime = now + temporalTTL;
   this.frameCount = 0;
 
   if (this.fps) {

--- a/lib/servo.js
+++ b/lib/servo.js
@@ -243,7 +243,6 @@ Servo.prototype.to = function(degrees, time, rate) {
         degrees: typeof degrees.degrees === "number" ? degrees.degrees : this.startAt
       }],
       oncomplete: function() {
-        this.stop();
         process.nextTick(this.emit.bind(this, "move:complete"));
       }.bind(this)
     };


### PR DESCRIPTION
This works now
````
var five = require("johnny-five");
var Tessel = require("tessel-io");
var board = new five.Board({
  io: new Tessel()
});
board.on("ready", function() {
  var led = new five.Led("a5");
  var fader = () => {
    var easing = easingFns.shift();
    led.off().fade({ easing }, 1000, fader);
  };

  fader();
});


var easingFns = [
  "inQuad",
  "outQuad",
  "inOutQuad",
  "inCube",
  "outCube",
  "inOutCube",
  "inQuart",
  "outQuart",
  "inOutQuart",
  "inQuint",
  "outQuint",
  "inOutQuint",
  "inSine",
  "outSine",
  "inOutSine",
  "inExpo",
  "outExpo",
  "inOutExpo",
  "inCirc",
  "outCirc",
  "inOutCirc",
  "inBack",
  "outBack",
  "inOutBack",
  "inBounce",
  "outBounce",
  "inOutBounce",
];
````

We had two problems. 

First, temporal.stop was clearing out it's array of tasks on nextTick which meant that the next animation was already loaded into temporal. Had to defer onComplete to nextTick as well.

Second, there was a second call to next() firing after the second segment had been loaded. next() should only fire if there is a segment waiting on the array.

Also added some comments.