### PR TITLE
make gitter badge image valid common mark

### DIFF
--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -9,7 +9,7 @@ _Artwork by [Mike Sgier](http://msgierillustration.com)_
 
 [![Travis Build Status](https://travis-ci.org/rwaldron/johnny-five.svg?branch=master)](https://travis-ci.org/rwaldron/johnny-five)
 [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/hmke71k7uemtnami/branch/master?svg=true)](https://ci.appveyor.com/project/rwaldron/johnny-five)
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/rwaldron/johnny-five?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/rwaldron/johnny-five?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 


### PR DESCRIPTION
fixes issue where gitter badge is not displaying on npmjs.com package page
spaces in image paths are not valid common mark, replaced with `%20`