### PR TITLE
Restore handling of 0 value

### DIFF
--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -230,11 +230,10 @@ Led.prototype.on = function() {
     }
 
     // ...the last value was 0
-    // This may be unnecessary?
     /* istanbul ignore if */
-    // if (state.value === 0) {
-    //   state.value = 255;
-    // }
+    if (state.value === 0) {
+      state.value = 255;
+    }
   }
 
   this.update();


### PR DESCRIPTION
Was preparing for NBD and found that blink() did not work on Tessel 2 because pin mode was PWM and we weren't handling cases of ```state.value === 0``` for that.

This situation arises in experiment 1 of the guide for J5IK.