### PR TITLE
Improve LCD millisecond delay handling

### DIFF
--- a/lib/lcd.js
+++ b/lib/lcd.js
@@ -12,7 +12,9 @@ var priv = new Map();
  */
 function sleep(ms) {
   var start = Date.now();
-  while (Date.now() < start + ms) {}
+  // Wait 1ms longer than requested. For further information see:
+  // https://github.com/rwaldron/johnny-five/issues/326#issuecomment-230125813
+  while (Date.now() < start + ms + 1) {}
 }
 
 


### PR DESCRIPTION
The LCD sleep function is currently implemented as follows:
```js
function sleep(ms) {
  var start = Date.now();
  while (Date.now() < start + ms) {}
}
```
As discussed [here](https://github.com/rwaldron/johnny-five/issues/326#issuecomment-230125813), the current implementation will often sleep for less than the requested number of milliseconds.

The modification to the sleep function introduced by this PR ensures that the sleep function sleeps for at least the requested number of milliseconds.