### PR TITLE
Add Piezo events when notes play

### DIFF
--- a/docs/piezo.md
+++ b/docs/piezo.md
@@ -79,6 +79,10 @@ board.on("ready", function() {
     tempo: 100
   });
 
+  piezo.on("note", function(data) {
+    console.log("Playing Note: ", data.note, data.beat, data.hz, data.duration);
+  });
+
 });
 
 ```
@@ -97,7 +101,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2016 The Johnny-Five Contributors
+Copyright (c) 2017 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/eg/piezo.js
+++ b/eg/piezo.js
@@ -48,4 +48,8 @@ board.on("ready", function() {
     tempo: 100
   });
 
+  piezo.on("note", function(data) {
+    console.log("Playing Note: ", data.note, data.beat, data.hz, data.duration);
+  });
+
 });

--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -403,6 +403,8 @@ Piezo.ToSong = function(stringSong, beats) {
   return song;
 };
 
+util.inherits(Piezo, Emitter);
+
 Piezo.prototype.note = function(note, duration) {
   var tone = Piezo.Parsers.hzFromInput(note);
 
@@ -519,7 +521,5 @@ Piezo.prototype.stop = function() {
 
   return this;
 };
-
-util.inherits(Piezo, Emitter);
 
 module.exports = Piezo;

--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -1,4 +1,6 @@
 var Board = require("./board");
+var Emitter = require("events").EventEmitter;
+var util = require("util");
 var Timer = require("nanotimer");
 
 var MICROSECONDS_PER_SECOND = 1000000;
@@ -308,7 +310,7 @@ Piezo.Parsers.hzFromInput = function(input) {
 
   // Is it a valid frequency?
   if (typeof output === "number" &&
-      Piezo.Frequencies[output]) {
+    Piezo.Frequencies[output]) {
     return output;
   }
 
@@ -475,8 +477,20 @@ Piezo.prototype.play = function(tune, callback) {
 
     if (hz === null) {
       this.noTone();
+      this.emit('note', {
+        note: '-',
+        beat: beat,
+        hz: hz,
+        duration: duration
+      });
     } else {
       this.frequency(hz, duration);
+      this.emit('note', {
+        note: note[0],
+        beat: beat,
+        hz: hz,
+        duration: duration
+      });
     }
 
     state.timeout = setTimeout(next, duration);
@@ -506,5 +520,6 @@ Piezo.prototype.stop = function() {
   return this;
 };
 
+util.inherits(Piezo, Emitter);
 
 module.exports = Piezo;

--- a/test/piezo.js
+++ b/test/piezo.js
@@ -436,7 +436,11 @@ exports["Piezo"] = {
       // OK to pass frequency directly...
       test.ok(this.frequency.calledWith(672, 60000 / tempo));
       // Does not mutate input song array
-      test.deepEqual(song, [["c", 1], ["d", 2], [null, 1], 672, "e4", null]);
+      test.deepEqual(song, [
+        ["c", 1],
+        ["d", 2],
+        [null, 1], 672, "e4", null
+      ]);
       test.done();
     }.bind(this));
 
@@ -584,6 +588,44 @@ exports["Piezo"] = {
     }.bind(this));
   },
 
+  notesEmitEvents: function(test) {
+    test.expect(15);
+
+    var eventSpy = this.sandbox.spy();
+
+    this.clock.restore();
+    this.noTone = this.sandbox.spy(this.piezo, "noTone");
+    this.frequency = this.sandbox.spy(this.piezo, "frequency");
+
+    this.piezo.on("note", eventSpy);
+
+    this.piezo.play("c d -", function() {
+      test.equal(this.noTone.callCount, 1);
+      test.equal(this.frequency.callCount, 2);
+
+      test.equal(eventSpy.callCount, 3);
+
+      // c
+      test.equal(eventSpy.args[0][0].note, "c");
+      test.equal(eventSpy.args[0][0].beat, 1);
+      test.equal(eventSpy.args[0][0].hz, 262);
+      test.equal(eventSpy.args[0][0].duration, 240);
+
+      // d
+      test.equal(eventSpy.args[1][0].note, "d");
+      test.equal(eventSpy.args[1][0].beat, 1);
+      test.equal(eventSpy.args[1][0].hz, 294);
+      test.equal(eventSpy.args[1][0].duration, 240);
+
+      // -
+      test.equal(eventSpy.args[2][0].note, "-");
+      test.equal(eventSpy.args[2][0].beat, 1);
+      test.equal(eventSpy.args[2][0].hz, null);
+      test.equal(eventSpy.args[2][0].duration, 240);
+
+      test.done();
+    }.bind(this));
+  },
 
   stop: function(test) {
     test.expect(2);
@@ -784,7 +826,7 @@ exports["Piezo - I2C Backpack"] = {
     this.piezo.tone(262, 1000);
     test.equal(this.i2cWrite.callCount, 1);
     test.equal(this.i2cWrite.lastCall.args[0], 0xFF);
-    test.deepEqual(this.i2cWrite.lastCall.args[1], [ 1, 3, 1, 6, 0, 0, 3, 232 ]);
+    test.deepEqual(this.i2cWrite.lastCall.args[1], [1, 3, 1, 6, 0, 0, 3, 232]);
 
     // ...
     test.done();
@@ -806,7 +848,7 @@ exports["Piezo - I2C Backpack"] = {
     this.piezo.noTone();
     test.equal(this.i2cWrite.callCount, 1);
     test.equal(this.i2cWrite.lastCall.args[0], 0xFF);
-    test.deepEqual(this.i2cWrite.lastCall.args[1], [ 0, 3 ]);
+    test.deepEqual(this.i2cWrite.lastCall.args[1], [0, 3]);
 
     test.done();
   },


### PR DESCRIPTION
I realize it may seem odd to have the Piezo component emit events.  But this is the second time I've written something that I wanted to synchronize to music.  Instead of writing my own timers to synchronize with the `Piezo.play()` function, it is much more convenient to have the Piezo emit a "note" event and my hardware can respond to it:

```js
// example usage
piezo.on("note", function({note, beat, hz, duration}) {
    // synchronize some hardware to a song!
    console.log("Playing Note: ", note, beat, hz, duration);
});

piezo.play(song);
```

I'm torn on the event name of `"note"`.  Perhaps `"change"`?  or `"note-change"` is better?