### PR TITLE
Add support for BH1750 light sensor

### DIFF
--- a/lib/light.js
+++ b/lib/light.js
@@ -394,6 +394,40 @@ var Controllers = {
       }
     }
   },
+  BH1750: {
+    //http://rohmfs.rohm.com/en/products/databook/datasheet/ic/sensor/light/bh1750fvi-e.pdf
+    //code based on Arduino library https://github.com/claws/BH1750
+    //currently only "continuous H-resolution" mode supported
+    ADDRESSES: {
+      value: [0x23, 0x5C]
+    },
+    initialize: {
+      value: function(opts, dataHandler) {
+        var address = opts.address || 0x23;
+        var mode = opts.mode || 0x10;
+        opts.address = address;
+        this.io.i2cConfig(opts);
+        this.io.i2cWrite(address, mode);
+        var read = function() {
+          setTimeout(function() {
+            this.io.i2cReadOnce(address, 2, function(data) {
+              var raw = data[0];
+              raw <<= 8;
+              raw |= data[1];
+              dataHandler(raw);
+              read();
+            });
+          }.bind(this), 120);
+        }.bind(this);
+        read();
+      }
+    },
+    toIntensityLevel: {
+      value: function(raw) {
+        return toFixed(raw / 1.2, 2);
+      }
+    }
+  },
 };
 
 Controllers.ALSPT19 = Controllers["ALS-PT19"] = Controllers.DEFAULT;


### PR DESCRIPTION
This adds support for BH1750 light sensor, see datasheet info at http://rohmfs.rohm.com/en/products/databook/datasheet/ic/sensor/light/bh1750fvi-e.pdf