### PR TITLE
Fix Piezo.prototype.note()

### DIFF
--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -404,13 +404,13 @@ Piezo.ToSong = function(stringSong, beats) {
 /**
  * Play a note for a duration.
  * @param {string} note - see Piezo.Notes.  Case-insensitive.
- *   If an octave is not given, the configured default octave
- *   will be used.
+ *   If a note name without an octave number is given (e.g. "C#" instead of
+ *   "C#4") then the configured default octave will be used.
+ *   @see Piezo.prototype.defaultOctave
  * @param {number} duration - in milliseconds.
  */
 Piezo.prototype.note = function(note, duration) {
-  var frequency = Piezo.Parsers.hzFromInput(note);
-  return this.frequency(frequency, duration);
+  return this.frequency(Piezo.Parsers.hzFromInput(note), duration);
 };
 
 /**

--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -401,16 +401,37 @@ Piezo.ToSong = function(stringSong, beats) {
   return song;
 };
 
+/**
+ * Play a note for a duration.
+ * @param {string} note - see Piezo.Notes.  Case-insensitive.
+ *   If an octave is not given, the configured default octave
+ *   will be used.
+ * @param {number} duration - in milliseconds.
+ */
 Piezo.prototype.note = function(note, duration) {
-  var tone = Piezo.Parsers.hzFromInput(note);
-
-  return this.tone(tone, duration);
+  var frequency = Piezo.Parsers.hzFromInput(note);
+  return this.frequency(frequency, duration);
 };
 
+/**
+ * Play a tone for a duration.
+ * This is a lower-level method than frequency (which does
+ * the translation from frequency to tone for you). Most of
+ * the time you likely want to use frequency.
+ * @param {number} tone - Given as a computed duty-cycle,
+ *   in microseconds. Larger values produce lower tones.
+ *   See https://en.wikipedia.org/wiki/Duty_cycle
+ * @param {number} duration - in milliseconds.
+ */
 Piezo.prototype.tone = function(tone, duration) {
   return this.frequency(Piezo.ToFrequency(tone), duration);
 };
 
+/**
+ * Play a frequency for a duration.
+ * @param {number} frequency - in Hz
+ * @param {number} duration - in milliseconds
+ */
 Piezo.prototype.frequency = function(frequency, duration) {
   return this.tone(Piezo.ToTone(frequency), duration);
 };

--- a/test/piezo.js
+++ b/test/piezo.js
@@ -371,7 +371,7 @@ exports["Piezo"] = {
     test.equal(returned, this.piezo);
 
     // A4 = 440Hz = 1136μs duty
-    var returned = this.piezo.frequency(440, 100);
+    returned = this.piezo.frequency(440, 100);
     test.deepEqual(toneSpy.getCall(1).args, [1136, 100]);
     test.equal(returned, this.piezo);
 


### PR DESCRIPTION
Fixes #1323 - FYI @lyzadanger.

The `note()` method was passing a frequency (Hz) to the `tone()` method, which is expecting to receive a duty cycle (μs), leading to the wrong note being played.  The solution is for `note()` to call `frequency()` instead, which will do the appropriate conversion.

Since it took me a while to understand the relationships between `tone`, `frequency` and `note` I've added some documentation to those methods to clear things up for the next person.  I've also made some unit tests more aggressive about checking that values are converted appropriately as they're passed around, and commented note-frequency-duty equivalencies to help the test read nicer.

~Question: How is the documentation at http://johnny-five.io/api/piezo/#api generated?  The documentation for `tone` there was very helpful in understanding the intent of these methods, but it's also confusing because the first argument is misnamed in the signature `tone(frequency, duration)`.  I couldn't find a way to update that from this repo.~ EDIT: Found the docs on the repository wiki and [updated accordingly](https://github.com/rwaldron/johnny-five/wiki/Piezo/_compare/a0a2b6c80e84dfca906e29700df2910ab6cf3185...387fa1dc1af8e657f40d63aa51de262e13245a10).