### PR TITLE
Make unit tests less flaky on Travis CI

### DIFF
--- a/test/animation.js
+++ b/test/animation.js
@@ -243,7 +243,10 @@ exports["Animation -- Servo"] = {
   },
 
   keyframeEasing: function(test) {
-
+    // Don't allow time to advance in this test.  Otherwise it's possible for
+    // the animation to progress between setup and the assertion, causing flaky
+    // failures.
+    this.sandbox.useFakeTimers();
     this.animation = new Animation(this.a);
     test.expect(1);
 
@@ -260,7 +263,8 @@ exports["Animation -- Servo"] = {
     var indices = this.animation.findIndices(progress);
     var val = this.animation.tweenedValue(indices, progress);
 
-    test.ok(Math.abs(val - 74.843 < 0.01));
+    test.ok(Math.abs(val - 74.843) < 0.01,
+      "Expected " + val + " to be within 0.01 of 74.843");
     test.done();
   },
 

--- a/test/repl.js
+++ b/test/repl.js
@@ -44,9 +44,16 @@ exports["Repl"] = {
       debug: false
     });
 
+    // Extra-careful guard against calling test.done() twice here.
+    // This was causing "Cannot read property 'setUp' of undefined" errors
+    // See https://github.com/caolan/nodeunit/issues/234
+    var calledTestDone = false;
     var reallyExit = this.sandbox.stub(process, "reallyExit", function() {
       reallyExit.restore();
-      test.done();
+      if (!calledTestDone) {
+        calledTestDone = true;
+        test.done();
+      }
     });
 
     board.on("ready", function() {


### PR DESCRIPTION
I believe I've identified and fixed the two top causes of flaky failures in the Travis CI builds. I've provided inline comments for each fix.

### Existing failure rate
For a baseline, I looked at the last five builds on `master`: [2574](https://travis-ci.org/rwaldron/johnny-five/builds/222835946), [2573](https://travis-ci.org/rwaldron/johnny-five/builds/222109930), [2569](https://travis-ci.org/rwaldron/johnny-five/builds/221795739), [2568](https://travis-ci.org/rwaldron/johnny-five/builds/221793037), and [2567](https://travis-ci.org/rwaldron/johnny-five/builds/221778389).

- Total jobs: 50 (10 per build)
- Failures: 4 jobs / 8%
  - `Animation -- Servo - keyframeEasing`
    - [2574.6](https://travis-ci.org/rwaldron/johnny-five/jobs/222835952)
  - `Cannot read property 'setUp' of undefined`
    - [2574.10](https://travis-ci.org/rwaldron/johnny-five/jobs/222835956)
    - [2568.9](https://travis-ci.org/rwaldron/johnny-five/jobs/221793046)
    - [2567.9](https://travis-ci.org/rwaldron/johnny-five/jobs/221778398)

I've seen both of these on my own pull requests recently too - they seem to be fairly common.

### New failure rate
Considering builds: [2578 (PR)](https://travis-ci.org/rwaldron/johnny-five/builds/224164000), [2579 (PR)](https://travis-ci.org/rwaldron/johnny-five/builds/224169626), [2580 (PR)](https://travis-ci.org/rwaldron/johnny-five/builds/224170521), [41](https://travis-ci.org/code-dot-org/johnny-five/builds/224162626), [42](https://travis-ci.org/code-dot-org/johnny-five/builds/224169608), and [43](https://travis-ci.org/code-dot-org/johnny-five/builds/224170493).

- Total jobs: 60 (10 per build)
- Failures: None!

