### PR TITLE
Fix tests on Node v0.10.x

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -332,7 +332,7 @@ exports["Collection.Emitter"] = {
   },
 
   "Symbol.iterator": function(test) {
-    if (Symbol && Symbol.iterator) {
+    if (typeof Symbol !== "undefined" && Symbol.iterator) {
       test.expect(1);
       test.equal(Collection.prototype[Symbol.iterator], Array.prototype[Symbol.iterator]);
     }


### PR DESCRIPTION
We [discussed here](https://github.com/rwaldron/johnny-five/commit/be3e8bd6211c6c1c1c25613d2bb7cc487466a581#commitcomment-21991716) a safe check for whether `Symbol` is available in the current node version (it's not, in node v0.10).  Three cases [were fixed here](https://github.com/rwaldron/johnny-five/commit/2884c2e5120b6eb1b8e91de806b238825ff68ba1) but a fourth was missed, causing tests to continue failing on node v0.10.x.  This fixes that fourth case.