### PR TITLE
Give Thermometer enable/disable methods

### DIFF
--- a/lib/thermometer.js
+++ b/lib/thermometer.js
@@ -928,8 +928,6 @@ function Thermometer(opts) {
     this, opts = Board.Options(opts)
   );
 
-  var freq = opts.freq || 25;
-
   // Analog Reference Voltage (default to board.io.aref || 5)
   this.aref = opts.aref || this.io.aref || 5;
 
@@ -943,7 +941,13 @@ function Thermometer(opts) {
     controller = Controllers.ANALOG;
   }
 
-  priv.set(this, {});
+  var state = {
+    enabled: typeof opts.enabled === "undefined" ? true : opts.enabled,
+    intervalId: null,
+    freq: opts.freq || 25,
+    previousFreq: opts.freq || 25,
+  };
+  priv.set(this, state);
 
   Board.Controller.call(this, controller, opts);
 
@@ -952,6 +956,25 @@ function Thermometer(opts) {
       return x;
     };
   }
+
+  // TODO: Move this out of the constructor
+  var eventProcessing = function() {
+    if (raw == null) {
+      return;
+    }
+
+    var data = {};
+    data.C = data.celsius = this.celsius;
+    data.F = data.fahrenheit = this.fahrenheit;
+    data.K = data.kelvin = this.kelvin;
+
+    this.emit("data", data);
+
+    if (this.celsius !== last) {
+      last = this.celsius;
+      this.emit("change", data);
+    }
+  }.bind(this);
 
   var descriptors = {
     celsius: {
@@ -968,7 +991,22 @@ function Thermometer(opts) {
       get: function() {
         return toFixed(this.celsius + CELSIUS_TO_KELVIN, 2);
       }
-    }
+    },
+    freq: {
+      get: function() {
+        return state.freq;
+      },
+      set: function(newFreq) {
+        state.freq = newFreq;
+        if (state.intervalId) {
+          clearInterval(state.intervalId);
+        }
+
+        if (state.freq !== null) {
+          state.intervalId = setInterval(eventProcessing, newFreq);
+        }
+      }
+    },
   };
   // Convenience aliases
   descriptors.C = descriptors.celsius;
@@ -983,26 +1021,50 @@ function Thermometer(opts) {
     });
   }
 
-  setInterval(function() {
-    if (raw == null) {
-      return;
-    }
-
-    var data = {};
-    data.C = data.celsius = this.celsius;
-    data.F = data.fahrenheit = this.fahrenheit;
-    data.K = data.kelvin = this.kelvin;
-
-    this.emit("data", data);
-
-    if (this.celsius !== last) {
-      last = this.celsius;
-      this.emit("change", data);
-    }
-  }.bind(this), freq);
+  // Set the freq property only after the get and set functions are defined
+  // and only if the sensor is not `enabled: false`
+  if (state.enabled) {
+    this.freq = state.freq;
+  }
 }
 
 util.inherits(Thermometer, Emitter);
+
+/**
+ * enable Enable a disabled thermometer.
+ *
+ * @return {Object} instance
+ *
+ */
+Thermometer.prototype.enable = function() {
+  var state = priv.get(this);
+
+  /* istanbul ignore else */
+  if (!state.enabled) {
+    this.freq = state.freq || state.previousFreq;
+  }
+
+  return this;
+};
+
+/**
+ * disable Disable an enabled thermometer.
+ *
+ * @return {Object} instance
+ *
+ */
+Thermometer.prototype.disable = function() {
+  var state = priv.get(this);
+
+  /* istanbul ignore else */
+  if (state.enabled) {
+    state.enabled = false;
+    state.previousFreq = state.freq;
+    this.freq = null;
+  }
+
+  return this;
+};
 
 Thermometer.Drivers = Drivers;
 

--- a/test/board.js
+++ b/test/board.js
@@ -490,7 +490,7 @@ exports["Board"] = {
   },
 
   snapshot: function(test) {
-    test.expect(68);
+    test.expect(69);
 
     new Multi({
       controller: "BME280",
@@ -626,7 +626,8 @@ exports["Board"] = {
         F: 32,
         celsius: 0,
         kelvin: 273.15,
-        aref: 5
+        aref: 5,
+        freq: 25
       }, {
         freq: 25,
         constrained: 0,

--- a/test/thermometer.js
+++ b/test/thermometer.js
@@ -109,6 +109,88 @@ function testAnalogChange(test) {
   test.done();
 }
 
+function testConstructDisabled(test) {
+  this.thermometer = new Thermometer({
+    controller: this.thermometer.controller,
+    pin: this.thermometer.pin,
+    freq: this.thermometer.freq,
+    board: this.board,
+    enabled: false,
+  });
+
+  var raw = this.analogRead.firstCall.yield.bind(this.analogRead.firstCall);
+  var spy = this.sandbox.spy();
+
+  test.expect(2);
+
+  this.thermometer.on("change", spy);
+
+  raw(100);
+  this.clock.tick(this.freq);
+  raw(200);
+  this.clock.tick(this.freq);
+
+  test.equal(spy.callCount, 0);
+
+  this.thermometer.enable();
+
+  raw(100);
+  this.clock.tick(this.freq);
+  raw(200);
+  this.clock.tick(this.freq);
+
+  test.equal(spy.callCount, 1);
+  test.done();
+}
+
+function testEnable(test) {
+  var raw = this.analogRead.firstCall.yield.bind(this.analogRead.firstCall);
+  var spy = this.sandbox.spy();
+
+  test.expect(2);
+
+  this.thermometer.disable();
+
+  this.thermometer.on("change", spy);
+
+  raw(100);
+  this.clock.tick(this.freq);
+  raw(200);
+  this.clock.tick(this.freq);
+
+  test.equal(spy.callCount, 0);
+
+  this.thermometer.enable();
+
+  raw(100);
+  this.clock.tick(this.freq);
+  raw(200);
+  this.clock.tick(this.freq);
+
+  test.equal(spy.callCount, 2);
+  test.done();
+}
+
+function testDisable(test) {
+  var raw = this.analogRead.firstCall.yield.bind(this.analogRead.firstCall);
+  var spy = this.sandbox.spy();
+
+  test.expect(1);
+
+  this.thermometer.disable();
+
+  this.thermometer.on("change", spy);
+
+  raw(100);
+  this.clock.tick(this.freq);
+  raw(200);
+  this.clock.tick(this.freq);
+
+  test.equal(spy.callCount, 0);
+
+  test.done();
+}
+
 function testShape(test) {
   test.expect(this.proto.length + this.instance.length);
 
@@ -219,6 +301,9 @@ exports["Thermometer -- ANALOG"] = {
 
     shape: testShape,
     change: testAnalogChange,
+    enable: testEnable,
+    disable: testDisable,
+    constructDisabled: testConstructDisabled,
 
     rawData: makeTestAnalogConversion({
       raw: 50,
@@ -296,6 +381,9 @@ exports["Thermometer -- ANALOG"] = {
       K: 373,
     }),
     change: testAnalogChange,
+    enable: testEnable,
+    disable: testDisable,
+    constructDisabled: testConstructDisabled,
     digits: function(test) {
       test.expect(1);
       test.equal(digits.fractional(this.thermometer.C), 0);
@@ -335,6 +423,9 @@ exports["Thermometer -- ANALOG"] = {
       K: 378,
     }),
     change: testAnalogChange,
+    enable: testEnable,
+    disable: testDisable,
+    constructDisabled: testConstructDisabled,
     digits: function(test) {
       test.expect(1);
       test.equal(digits.fractional(this.thermometer.C), 0);
@@ -356,6 +447,9 @@ exports["Thermometer -- ANALOG"] = {
 
     shape: testShape,
     change: testAnalogChange,
+    enable: testEnable,
+    disable: testDisable,
+    constructDisabled: testConstructDisabled,
 
     aref: makeTestAnalogConversion({
       aref: 3.3,
@@ -416,7 +510,10 @@ exports["Thermometer -- ANALOG"] = {
       test.expect(1);
       test.equal(digits.fractional(this.thermometer.C), 0);
       test.done();
-    }
+    },
+    enable: testEnable,
+    disable: testDisable,
+    constructDisabled: testConstructDisabled,
   },
 
   TINKERKIT: {
@@ -450,7 +547,10 @@ exports["Thermometer -- ANALOG"] = {
       test.expect(1);
       test.equal(digits.fractional(this.thermometer.C), 0);
       test.done();
-    }
+    },
+    enable: testEnable,
+    disable: testDisable,
+    constructDisabled: testConstructDisabled,
   },
 };
 


### PR DESCRIPTION
Addresses https://github.com/rwaldron/johnny-five/issues/1297 by giving the `Thermometer` component `enable()` and `disable()` methods.

I've added tests but I'm a little confused by the structure of the Thermometer unit tests - this feature lives on the prototype and should be the same for all controllers, but it looks like it has to be tested per-controller?  But similar tests aren't applied to all controllers either.  Let me know if I should make sure these tests get added to every controller, or if we can run them just once on the default controller, etc.

Thanks!