### PR TITLE
Handle number as first value of servo keyframes

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -320,6 +320,14 @@ Servo.prototype[Animation.normalize] = function(keyFrames) {
       value: last
     };
   }
+
+  // If user passes a step as the first element in keyFrames use current position + step
+  if (typeof keyFrames[0] === "number") {
+    keyFrames[0] = {
+      value: last + keyFrames[0]
+    };
+  }
+
   return keyFrames.map(function(frame) {
     var value = frame;
 

--- a/test/led.collection.js
+++ b/test/led.collection.js
@@ -104,7 +104,7 @@ exports["Led.Collection"] = {
 
 
   "Animation.normalize": function(test) {
-    test.expect(2);
+    test.expect(3);
 
     var leds = new Led.Collection([
       this.a, this.b, this.c
@@ -157,6 +157,36 @@ exports["Led.Collection"] = {
       [
         { value: 0, easing: "linear" },
         { value: 255, easing: "linear" },
+      ],
+      [
+        { value: 0, easing: "linear" },
+        { value: 255, easing: "linear" },
+      ],
+    ]);
+
+    normalized = leds[Animation.normalize]([
+      [
+        0,
+        128
+      ],
+      [
+        10,
+        220,
+      ],
+      [
+        0,
+        255,
+      ],
+    ]);
+
+    test.deepEqual(normalized, [
+      [
+        { value: 0, easing: "linear" },
+        { value: 128, easing: "linear" }
+      ],
+      [
+        { value: 10, easing: "linear" },
+        { value: 220, easing: "linear" },
       ],
       [
         { value: 0, easing: "linear" },

--- a/test/led.js
+++ b/test/led.js
@@ -543,6 +543,21 @@ exports["Led - PWM"] = {
     test.done();
   },
 
+  "Animation.normalize (first keyframe is number)": function(test) {
+    test.expect(1);
+    
+    this.led.brightness(45);
+    
+    var normalized = this.led[Animation.normalize]([
+      10,
+      255,
+      { value: 0 }
+    ]);
+
+    test.equal(normalized[0].value, 10);
+    test.done();
+  },
+
   "Animation.render": function(test) {
     test.expect(1);
     this.update = this.sandbox.stub(this.led, "update");

--- a/test/servo.collection.js
+++ b/test/servo.collection.js
@@ -128,7 +128,7 @@ exports["Servo.Collection"] = {
   },
 
   "Animation.normalize": function(test) {
-    test.expect(2);
+    test.expect(3);
 
     var servos = new Servo.Collection([
       this.a, this.b, this.c
@@ -184,6 +184,36 @@ exports["Servo.Collection"] = {
       ],
       [
         { value: servos[1].startAt, easing: "linear" },
+        { step: 10, easing: "linear" },
+      ],
+    ]);
+
+    normalized = servos[Animation.normalize]([
+      [
+        20,
+        40
+      ],
+      [
+        null,
+        10,
+      ],
+      [
+        30,
+        10,
+      ],
+    ]);
+
+    test.deepEqual(normalized, [
+      [
+        { value: servos[0].startAt + 20, easing: "linear" },
+        { step: 40, easing: "linear" },
+      ],
+      [
+        { value: servos[1].startAt, easing: "linear" },
+        { step: 10, easing: "linear" },
+      ],
+      [
+        { value: servos[2].startAt + 30, easing: "linear" },
         { step: 10, easing: "linear" },
       ],
     ]);

--- a/test/servo.js
+++ b/test/servo.js
@@ -1057,6 +1057,20 @@ exports["Servo"] = {
     test.done();
   },
 
+  "Animation.normalize (first keyframe is step)": function(test) {
+    test.expect(1);
+    this.servo = new Servo({
+      board: this.board,
+      pin: 11,
+    });
+
+    this.servo.to(45);
+    var normalized = this.servo[Animation.normalize]([45, 45, -90, 11]);
+
+    test.equal(normalized[0].value, 90);
+    test.done();
+  },
+
   "Animation.render": function(test) {
     test.expect(2);
 


### PR DESCRIPTION
When number is passed as the first keyframe of a servo animation it should be treated as a step from the most recent position.

Also adds tests for led to ensure that number values in first keyframe are still treated as explicit values.

Will close #1374 

Note that when this lands I need to update the animation wiki to better describe all devices that can be animated.