### PR TITLE
LED.isAnode does not work for OUTPUT mode

### DIFF
--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -34,8 +34,14 @@ var Controllers = {
       writable: true,
       value: function(input) {
         var state = priv.get(this);
-        var output = typeof input !== "undefined" ? input : state.value;
-        var value = state.isAnode ? 255 - Board.constrain(output, 0, 255) : output;
+        var value = typeof input !== "undefined" ? input : state.value;
+
+        if (this.mode == this.io.MODES.PWM) {
+          value = state.isAnode ? 255 - Board.constrain(value, 0, 255) : value;
+        } else if (state.isAnode) {
+          value = value == this.io.LOW ? this.io.HIGH : this.io.LOW;
+        }
+
         this.write(value);
       }
     },
@@ -81,8 +87,13 @@ var Controllers = {
       writable: true,
       value: function(input) {
         var state = priv.get(this);
-        var output = typeof input !== "undefined" ? input : state.value;
-        var value = state.isAnode ? 255 - Board.constrain(output, 0, 255) : output;
+        var value = typeof input !== "undefined" ? input : state.value;
+
+        if (this.mode == this.io.MODES.PWM) {
+          value = state.isAnode ? 255 - Board.constrain(value, 0, 255) : value;
+        } else if (state.isAnode) {
+          value = value == this.io.LOW ? this.io.HIGH : this.io.LOW;
+        }
 
         // If pin is not a PWM pin and brightness is not HIGH or LOW, emit an error
         if (value !== this.io.LOW && value !== this.io.HIGH && this.mode !== this.io.MODES.PWM) {
@@ -91,10 +102,6 @@ var Controllers = {
             type: "PWM",
             via: "Led"
           });
-        }
-
-        if (state.mode === this.io.MODES.OUTPUT) {
-          value = output;
         }
 
         this.write(value);

--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -36,10 +36,10 @@ var Controllers = {
         var state = priv.get(this);
         var value = typeof input !== "undefined" ? input : state.value;
 
-        if (this.mode == this.io.MODES.PWM) {
+        if (this.mode === this.io.MODES.PWM) {
           value = state.isAnode ? 255 - Board.constrain(value, 0, 255) : value;
         } else if (state.isAnode) {
-          value = value == this.io.LOW ? this.io.HIGH : this.io.LOW;
+          value = value === this.io.LOW ? this.io.HIGH : this.io.LOW;
         }
 
         this.write(value);
@@ -89,10 +89,10 @@ var Controllers = {
         var state = priv.get(this);
         var value = typeof input !== "undefined" ? input : state.value;
 
-        if (this.mode == this.io.MODES.PWM) {
+        if (this.mode === this.io.MODES.PWM) {
           value = state.isAnode ? 255 - Board.constrain(value, 0, 255) : value;
         } else if (state.isAnode) {
-          value = value == this.io.LOW ? this.io.HIGH : this.io.LOW;
+          value = value === this.io.LOW ? this.io.HIGH : this.io.LOW;
         }
 
         // If pin is not a PWM pin and brightness is not HIGH or LOW, emit an error

--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -37,8 +37,8 @@ var Controllers = {
         var value = typeof input !== "undefined" ? input : state.value;
 
         if (this.mode === this.io.MODES.PWM) {
-          value = state.isAnode ? 255 - Board.constrain(value, 0, 255) : value;
-        } else if (state.isAnode) {
+          value = state.inverted ? 255 - Board.constrain(value, 0, 255) : value;
+        } else if (state.inverted) {
           value = value === this.io.LOW ? this.io.HIGH : this.io.LOW;
         }
 
@@ -90,8 +90,8 @@ var Controllers = {
         var value = typeof input !== "undefined" ? input : state.value;
 
         if (this.mode === this.io.MODES.PWM) {
-          value = state.isAnode ? 255 - Board.constrain(value, 0, 255) : value;
-        } else if (state.isAnode) {
+          value = state.inverted ? 255 - Board.constrain(value, 0, 255) : value;
+        } else if (state.inverted) {
           value = value === this.io.LOW ? this.io.HIGH : this.io.LOW;
         }
 
@@ -163,8 +163,16 @@ function Led(opts) {
 
   Object.defineProperties(this, controller);
 
+  /**
+    * @deprecated Will be deleted in version 0.11.8. Use 'inverted' instead.
+  */
+  if (typeof opts.isAnode !== 'undefined' && opts.isAnode !== null) {
+    console.log("isAnode is deprecated. Use 'inverted' instead");
+    opts.inverted = opts.isAnode;
+  }
+
   var state = {
-    isAnode: opts.isAnode,
+    inverted: opts.inverted,
     isOn: false,
     isRunning: false,
     value: null,


### PR DESCRIPTION
I fixed a problem in isAnode in the component of the LED that I just implemented in PWM mode.
In this item is discussed to change the name to invert (yet to be done).
[#1026](https://github.com/rwaldron/johnny-five/issues/1026)