### PR TITLE
Offset was being applied twice when to() was called with a time

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -35,6 +35,7 @@ var Controllers = {
       writable: true,
       value: function(degrees) {
         var state = priv.get(this);
+        this.value = degrees;
         state.expander.servoWrite(this.pin, degrees);
       }
     }
@@ -70,6 +71,7 @@ var Controllers = {
           return this;
         }
 
+        this.value = degrees;
         this.io.servoWrite(this.pin, degrees);
       }
     }
@@ -262,9 +264,6 @@ Servo.prototype.to = function(degrees, time, rate) {
 
     // Enforce limited range of motion
     degrees = Fn.constrain(degrees, this.range[0], this.range[1]);
-    degrees += this.offset;
-
-    this.value = degrees;
 
     if (typeof time !== "undefined") {
 
@@ -277,6 +276,8 @@ Servo.prototype.to = function(degrees, time, rate) {
       this.to(options);
 
     } else {
+      
+      degrees += this.offset;
       
       if (this.invert) {
         degrees = Fn.map(

--- a/test/extended/servo.js
+++ b/test/extended/servo.js
@@ -204,6 +204,43 @@ exports["Servo"] = {
 
   },
 
+  toDegreesAndTimeWithOffset: function(test) {
+    test.expect(1);
+    
+    this.servo = new Servo({
+      board: this.board,
+      pin: 11,
+      offset: -10
+    });
+
+    this.servo.to(80, 100);
+
+    this.servo.on("move:complete", function() {
+      test.equal(this.servo.value, 70);
+      test.done();
+    }.bind(this));
+    
+  },
+
+  toDegreesAndTimeWithOffsetAndInvert: function(test) {
+    test.expect(1);
+    
+    this.servo = new Servo({
+      board: this.board,
+      pin: 11,
+      offset: -10,
+      invert: true
+    });
+
+    this.servo.to(80, 100);
+
+    this.servo.on("move:complete", function() {
+      test.equal(this.servo.value, 110);
+      test.done();
+    }.bind(this));
+    
+  },
+
   /* These tests are commented out while we figure out Issue #829
   degreeChange: function(test) {
     test.expect(1);


### PR DESCRIPTION
Move application of offset so that is only applied once.

Move update of this.value to controller update methods. A little less DRY, but having them be more proximate to the actual servoWrite makes sense.

Fixes #1429