### PR TITLE
ADXL345: Use full-resolution sensitivity for all ranges.

### DIFF
--- a/lib/accelerometer.js
+++ b/lib/accelerometer.js
@@ -164,8 +164,7 @@ var Controllers = {
     initialize: {
       value: function(opts, dataHandler) {
         var READLENGTH = 6;
-        var address = opts.address || this.ADDRESSES[0];
-        var state = priv.get(this);
+        var address = opts.address || this.ADDRESSES[0];        
 
         opts.address = address;
 
@@ -224,23 +223,6 @@ var Controllers = {
           16: 3
         })[opts.range || 2];
 
-        /*
-          Page 4
-          Sensitivity at              Min   Typ  Max
-          ±2 g, 10-bit resolution     230   256  282
-          ±4 g, 10-bit resolution     115   128  141
-          ±8 g, 10-bit resolution      57    64   71
-          ±16 g, 10-bit resolution     29    32   35
-        */
-        state.sensitivity = [
-          256,
-          128,
-          64,
-          32,
-        ][range];
-
-        state.fdigits = 8 - range;
-
         // Merge the format and range bits to set the DATA_FORMAT
         this.io.i2cWrite(address, this.REGISTER.DATA_FORMAT, format | range);
 
@@ -258,12 +240,8 @@ var Controllers = {
         // From Table 1, page 4
         //
         // Sensitivity
-        // ±2 g, 10-bit resolution, 256LSB/g, 0.00390625g/LSB
-        // ±4 g, 10-bit resolution, 128LSB/g, 0.0078125g/LSB
-        // ±8 g, 10-bit resolution, 256LSB/g, 0.015625g/LSB
-        // ±16 g, 10-bit resolution, 256LSB/g, 0.03125g/LSB
-        var state = priv.get(this);
-        return toFixed(raw / state.sensitivity, state.fdigits);
+        // All g-ranges, full resolution, 256LSB/g, 0.00390625g/LSB
+        return toFixed(raw * 0.00390625, 8);
       }
     }
   },

--- a/test/accelerometer.js
+++ b/test/accelerometer.js
@@ -650,11 +650,11 @@ exports["Accelerometer -- ADXL345"] = {
 
     test.ok(changeSpy.calledOnce);
     test.deepEqual(changeSpy.args[0], [{
-      x: 0.09375,
-      y: 0.15625,
+      x: 0.01171875,
+      y: 0.01953125,
       // When this is converted back into a number,
       // the trailing 0 is discarded.
-      z: 7.9375
+      z: 0.9921875
     }]);
 
     test.done();
@@ -707,11 +707,11 @@ exports["Accelerometer -- ADXL345"] = {
 
     test.ok(changeSpy.calledOnce);
     test.deepEqual(changeSpy.args[0], [{
-      x: 0.046875,
-      y: 0.078125,
+      x: 0.01171875,
+      y: 0.01953125,
       // When this is converted back into a number,
       // the trailing 0 is discarded.
-      z: 3.96875
+      z: 0.9921875
     }]);
 
     test.done();


### PR DESCRIPTION
The output of an ADXL345 accelerometer is scaled incorrectly when initialized with a `range` value other than 2g.  The output is scaled using the sensitivity value for 10-bit resolution, when it should be scaled using the sensitivity value for full-resolution.

This can be demonstrated with the following code:

```
const five = require('johnny-five')
const board = new five.Board()

board.on('ready', () => {
  let accel = new five.Accelerometer({
    controller: 'ADXL345',
    range: 2
  })

  accel.on('change', () => {
    console.log(accel.x, accel.y, accel.z)
  })
})
```

Here is the (simplified) output using different values for `range` with the accelerometer lying flat on the table (Z-axis subject to a constant 1g):

* range=2: 0, 0, 1
* range=4: 0, 0, 2
* range=8: 0, 0, 4
* range=16: 0, 0, 8

Currently, the `toGravity()` method takes the raw value and divides by the sensitivity value corresponding to the _10-bit resolution_ for the specified range (256, 128, 64, 32), but this is incorrect because _the accelerometer is set to full-resolution mode_, not 10-bit resolution mode.  When in full-resolution mode, the sensitivity should be 256 for all ranges, as described in the datasheet (pg. 26):

>FULL_RES Bit - When this bit is set to a value of 1, the device is in full resolution mode, where the output resolution increases with the g range set by the range bits to maintain a 4 mg/LSB scale factor. When the FULL_RES bit is set to 0, the device is in 10-bit mode, and the range bits determine the maximum g range and scale factor.

Assuming there is no interest in switching to 10-bit resolution mode, the solution is to use a fixed sensitivity (256LSB/g = 0.00390625 g/LSB) for all ranges, which (using the test code above)
yields the expected results:

* range=2: 0, 0, 1
* range=4: 0, 0, 1
* range=8: 0, 0, 1
* range=16: 0, 0, 1
