### PR TITLE
Gyro: add MPU6050 and BNO055 devices resolution

### DIFF
--- a/lib/gyro.js
+++ b/lib/gyro.js
@@ -76,10 +76,19 @@ var Controllers = {
       }
     },
     toDegreesPerSecond: {
+      // Datasheet available at https://www.invensense.com/wp-content/uploads/2015/02/MPU-6000-Datasheet1.pdf
+      //
+      // From paragraph 6.1 at page 12
+      // Sensitivity scale factor
+      // FS_SEL=0    131 LSB/dps -> 0,007633588 dps/LSB
+      // FS_SEL=1    65.5 LSB/dps -> 0,015267176 dps/LSB
+      // FS_SEL=2    32.8 LSB/dps -> 0,00304878 dps/LSB
+      // FS_SEL=3    16.4 LSB/dps -> 0,06097561 dps/LSB
+      // Using 4 digits resolution
       value: function(raw, rawCenter) {
         var state = priv.get(this);
 
-        return (raw - rawCenter) / state.sensitivity;
+        return toFixed((raw - rawCenter) / state.sensitivity, 4);
       }
     }
   },
@@ -106,9 +115,13 @@ var Controllers = {
       }
     },
     toDegreesPerSecond: {
+      // Datasheet available at https://cdn-shop.adafruit.com/datasheets/BST_BNO055_DS000_12.pdf
+      //
+      // From Tble 3-22 at page 33
+      // Gyroscope unit settings 1dps = 16 LSB -> resolution 0,0625 dps with +=2000 dps range
       value: function(raw) {
         var state = priv.get(this);
-        return raw / state.sensitivity;
+        return toFixed(raw / state.sensitivity, 4);
       }
     }
   },
@@ -301,9 +314,9 @@ function Gyro(opts) {
           this.toDegreesPerSecond(state.z.value, state.z.center) : 0;
 
         return {
-          x: toFixed(x, 2),
-          y: toFixed(y, 2),
-          z: toFixed(z, 2)
+          x: x,
+          y: y,
+          z: z
         };
       }
     }

--- a/test/gyro.js
+++ b/test/gyro.js
@@ -199,7 +199,7 @@ exports["Gyro -- MPU6050"] = {
   data: function(test) {
     var read, spy = this.sandbox.spy();
 
-    test.expect(10);
+    test.expect(13);
     this.gyro.isCalibrated = true;
     this.gyro.on("data", spy);
 
@@ -221,6 +221,10 @@ exports["Gyro -- MPU6050"] = {
     test.equals(this.i2cRead.args[0][0], 0x68);
     test.deepEqual(this.i2cRead.args[0][1], 0x3B);
     test.equals(this.i2cRead.args[0][2], 14);
+
+    test.equal(digits.fractional(this.gyro.rate.x), 4);
+    test.equal(digits.fractional(this.gyro.rate.y), 4);
+    test.equal(digits.fractional(this.gyro.rate.z), 4);
 
     this.clock.tick(100);
 


### PR DESCRIPTION
Add test only for MPU6050 device.

Fix #1121 .