### PR TITLE
Serial port list throttling and repl error with multiple boards

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -1195,6 +1195,11 @@ function Boards(opts) {
       this.emit("error", error);
     }.bind(this));
 
+    // echo the fail event from the boards
+    this[index].on("fail", function (event) {
+      this.emit("fail", event);
+    }.bind(this));
+
     return new Promise(function(resolve) {
       this[index].on("ready", function() {
         resolve(initialized[portOpts.id]);

--- a/lib/board.js
+++ b/lib/board.js
@@ -25,11 +25,14 @@ var rport = /usb|acm|^com/i;
 // This string appears over 20 times in this file.
 var UNDEFINED = "undefined";
 
-
 var Serial = {
   used: [],
   attempts: [],
   detect: function(callback) {
+    // Max number of times listing serial conntections can fail
+    var maxAttempts = 10;
+    // Delay (ms) before trying again to list serial connections
+    var retryDelay = 400;
     var serialport;
 
     /* istanbul ignore if */
@@ -88,7 +91,14 @@ var Serial = {
         Serial.attempts[Serial.used.length]++;
 
         // Retry Serial connection
-        Serial.detect.call(this, callback);
+        if (Serial.attempts[Serial.used.length] > maxAttempts) {
+          this.fail("Board", "No connected device found");
+          return;
+        }
+        setTimeout(() => {
+          Serial.detect.call(this, callback);
+        }, retryDelay);
+
         return;
       }
 
@@ -431,11 +441,19 @@ function finalizeAndBroadcast(data, type, io) {
 
     if (io.name !== "Mock" && this.sigint) {
       process.on("SIGINT", function() {
+        // Time to wait before forcing exit
+        var failExitTimeout = 1000;
+
         this.emit("exit");
         this.warn("Board", "Closing.");
+
+        var timeout = setTimeout(function () {
+          process.reallyExit();
+        }, failExitTimeout);
         var interval = setInterval(function() {
           if (!this.io.pending) {
             clearInterval(interval);
+            clearTimeout(timeout);
             process.nextTick(process.reallyExit);
           }
         }.bind(this), 1);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -79,13 +79,37 @@ Repl.prototype.initialize = function(callback) {
   this.context = cmd.context;
 
   cmd.on("exit", function() {
+    // Time to wait before forcing exit
+    var failExitTimeout = 1000;
+
     state.board.emit("exit");
     state.board.warn("Board", "Closing.");
 
-    var interval = setInterval(function() {
-      /* istanbul ignore else */
-      if (!state.board.io.pending) {
+    // A fail safe timeout if 1 second to force exit.
+    var timeout = setTimeout(function () {
+      process.reallyExit();
+    }, failExitTimeout);
+
+    var interval = setInterval(function () {
+      var pendingIo = false;
+      // More than one board is attached, wait until everyone has no
+      // io pending before exit.
+      if (state.board.length) {
+        for (let i = 0; i < state.board.length; i++) {
+          if (state.board[i].io.pending) {
+            pendingIo = true;
+            break;
+          }
+        }
+      }
+      // Only one board connected, wait until there is no io pending before exit.
+      else {
+        pendingIo = state.board.io.pending;
+      }
+
+      if (!pendingIo) {
         clearInterval(interval);
+        clearTimeout(timeout);
         process.nextTick(process.reallyExit);
       }
     }, 1);


### PR DESCRIPTION
Reading issue #1406 I started playing with Board.detect and indeed in case
 of no connection the function gets called with no throttling.

I found a couple of other things too:

* if a connected board(s) is(are) disconnected while running, when terminating the process the SIGINT event gets sometimes ignored (it has happened running a board with `repl: true` and `repl: false`)
 
* if multiple boards are connected with `repl: true`, when exiting the process an error is thrown because `state.board.io.pending` is not defined

In this PR a simple solution to the first problem follows what @dtex suggests in the issue discussion, while for the other two I add a fail safe timer of 1 second to force exit and fix the code in the `repl.js` module to handle the case of multiple boards.

This is not definitive and I don't know how much of this is needed, I would like to know what do you think (@rwaldron @dtex).
