### PR TITLE
Add support for multi-turn, winch, 90 and 360 degree servos

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To get you up and running quickly, we provide a variety of examples for using ea
 
 To interactively navigate the examples, visit the [Johnny-Five examples](http://johnny-five.io/examples/) page on the official website. If you want to link directly to the examples in this repo, you can use one of the following links.
 
-**There are presently 362 example programs with code and diagrams!**
+**There are presently 363 example programs with code and diagrams!**
 
 <!--extract-start:examples-->
 
@@ -224,6 +224,7 @@ To interactively navigate the examples, visit the [Johnny-Five examples](http://
 - [Servo](https://github.com/rwaldron/johnny-five/blob/master/docs/servo.md)
 - [Servo - Continuous](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-continuous.md)
 - [Servo - Drive](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-drive.md)
+- [Servo - Multi-Turn](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-multi-turn.md)
 - [Servo - PCA9685](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-PCA9685.md)
 - [Servo - Prompt](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-prompt.md)
 - [Servo - Slider control](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-slider.md)

--- a/docs/servo-multi-turn.md
+++ b/docs/servo-multi-turn.md
@@ -1,0 +1,86 @@
+<!--remove-start-->
+
+# Servo - Multi-Turn
+
+<!--remove-end-->
+
+
+
+
+
+
+
+
+Run this example from the command line with:
+```bash
+node eg/servo-multi-turn.js
+```
+
+
+```javascript
+var five = require("johnny-five");
+var board = new five.Board();
+
+board.on("ready", function() {
+  var servo = new five.Servo({
+    pin: 10,
+    // Cheapo servo has limited PWM range
+    pwmRange: [600, 2370],
+    // This multi-turn servo can turn 2430 degrees or 6.75 revolutions
+    deviceRange: [0, 2430]
+  });
+
+  // Add servo to REPL (optional)
+  this.repl.inject({
+    servo: servo
+  });
+
+
+  // Servo API
+
+  // min()
+  //
+  // move the servo to its minimum position
+  //
+  // eg. servo.min();
+
+  // max()
+  //
+  // move the servo to its maximum position of 6.75 turns from the minimum
+  //
+  // eg. servo.max();
+
+  // center()
+  //
+  // centers the servo at 3 3/8 turns from the minimum
+  //
+  // servo.center();
+
+  // to( deg )
+  //
+  // Moves the servo to 2 whole turns from the minimum
+  //
+  // servo.to( 720 );
+
+});
+
+```
+
+
+
+
+
+
+
+
+&nbsp;
+
+<!--remove-start-->
+
+## License
+Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
+Licensed under the MIT license.
+Copyright (c) 2018 The Johnny-Five Contributors
+Licensed under the MIT license.
+
+<!--remove-end-->

--- a/eg/servo-multi-turn.js
+++ b/eg/servo-multi-turn.js
@@ -1,0 +1,45 @@
+var five = require("../lib/johnny-five.js");
+var board = new five.Board();
+
+board.on("ready", function() {
+  var servo = new five.Servo({
+    pin: 10,
+    // Cheapo servo has limited PWM range
+    pwmRange: [600, 2370],
+    // This multi-turn servo can turn 2430 degrees or 6.75 revolutions
+    deviceRange: [0, 2430]
+  });
+
+  // Add servo to REPL (optional)
+  this.repl.inject({
+    servo: servo
+  });
+
+
+  // Servo API
+
+  // min()
+  //
+  // move the servo to its minimum position
+  //
+  // eg. servo.min();
+
+  // max()
+  //
+  // move the servo to its maximum position of 6.75 turns from the minimum
+  //
+  // eg. servo.max();
+
+  // center()
+  //
+  // centers the servo at 3 3/8 turns from the minimum
+  //
+  // servo.center();
+
+  // to( deg )
+  //
+  // Moves the servo to 2 whole turns from the minimum
+  //
+  // servo.to( 720 );
+
+});

--- a/lib/esc.js
+++ b/lib/esc.js
@@ -32,9 +32,9 @@ var Controllers = {
     },
     write: {
       writable: true,
-      value: function(pin, degrees) {
+      value: function(pin, microseconds) {
         var state = priv.get(this);
-        state.expander.servoWrite(pin, degrees);
+        state.expander.servoWrite(pin, microseconds);
       }
     }
   },
@@ -56,8 +56,9 @@ var Controllers = {
     },
     write: {
       writable: true,
-      value: function(pin, degrees) {
-        this.io.servoWrite(pin, degrees);
+      value: function(pin, microseconds) {
+        microseconds |= 0;
+        this.io.servoWrite(pin, microseconds);
       }
     }
   }
@@ -295,7 +296,7 @@ ESC.prototype.speed = function(speed) {
   }
 
   if (noInterval) {
-    this.write(this.pin, Fn.fscale(speed, 0, 100, 0, 180));
+    this.write(this.pin, Fn.fscale(speed, 0, 100, this.pwmRange[0], this.pwmRange[1]));
 
     history.push({
       timestamp: Date.now(),
@@ -314,7 +315,7 @@ ESC.prototype.speed = function(speed) {
       throttle--;
     }
 
-    this.write(this.pin, (throttle * 180 / 100));
+    this.write(this.pin, Fn.fscale(throttle, 0, 100, this.pwmRange[0], this.pwmRange[1]));
 
     history.push({
       timestamp: Date.now(),
@@ -397,7 +398,7 @@ ESC.prototype.stop = function() {
   var history = state.history;
   var speed = this.type === "bidirectional" ? this.neutral : 0;
 
-  this.write(this.pin, Fn.fscale(speed, 0, 100, 0, 180));
+  this.write(this.pin, Fn.fscale(speed, 0, 100, this.pwmRange[0], this.pwmRange[1]));
 
   history.push({
     timestamp: Date.now(),

--- a/lib/expander.js
+++ b/lib/expander.js
@@ -681,9 +681,16 @@ var Controllers = {
     servoWrite: {
       value: function(pin, value) {
 
-        value = Board.constrain(value, 0, 180);
+        var off;
 
-        var off = Fn.map(value, 0, 180, this.pwmRange[0] / 4, this.pwmRange[1] / 4);
+        if (value < 544) {
+          value = Board.constrain(value, 0, 180);
+          off = Fn.map(value, 0, 180, this.pwmRange[0] / 4, this.pwmRange[1] / 4);
+        } else {
+          off = value / 4;
+        }
+
+        off |= 0;
 
         this.io.i2cWrite(this.address, [
           this.REGISTER.BASE + 4 * pin,

--- a/lib/servo.js
+++ b/lib/servo.js
@@ -33,9 +33,9 @@ var Controllers = {
     },
     update: {
       writable: true,
-      value: function(degrees) {
+      value: function(microseconds) {
         var state = priv.get(this);
-        state.expander.servoWrite(this.pin, degrees);
+        state.expander.servoWrite(this.pin, microseconds);
       }
     }
   },
@@ -62,15 +62,23 @@ var Controllers = {
     update: {
       writable: true,
       value: function(degrees) {
-        // Servo is restricted to integers
-        degrees |= 0;
 
         // If same degrees return immediately.
         if (this.last && this.last.degrees === degrees) {
           return this;
         }
 
-        this.io.servoWrite(this.pin, degrees);
+        // Map value from degreeRange to pwmRange
+        var microseconds = Fn.map(
+          degrees,
+          this.degreeRange[0], this.degreeRange[1],
+          this.pwmRange[0], this.pwmRange[1]
+        );
+        
+        // Restrict values to integers
+        microseconds |= 0;
+
+        this.io.servoWrite(this.pin, microseconds);
       }
     }
   }
@@ -97,6 +105,9 @@ function Servo(opts) {
     this, opts = Board.Options(opts)
   );
 
+  this.degreeRange = opts.degreeRange || [0, 180];
+  this.pwmRange = opts.pwmRange || [600, 2400];
+  this.range = opts.range || this.degreeRange;
   this.deadband = opts.deadband || [90, 90];
   this.fps = opts.fps || 100;
   this.offset = opts.offset || 0;
@@ -139,10 +150,7 @@ function Servo(opts) {
   }
   this.invert = opts.isInverted || opts.invert || false;
 
-  // Allow "setup"instructions to come from
-  // constructor options properties
-  this.startAt = 90;
-
+  
   // Collect all movement history for this servo
   // history = [
   //   {
@@ -150,6 +158,9 @@ function Servo(opts) {
   //     degrees: degrees
   //   }
   // ];
+
+  // Allow "setup"instructions to come from
+  // constructor options properties
 
   if (opts.controller && typeof opts.controller === "string") {
     controller = Controllers[opts.controller.toUpperCase()];
@@ -189,9 +200,11 @@ function Servo(opts) {
 
   // If "startAt" is defined and center is falsy
   // set servo to min or max degrees
-  if (opts.startAt !== undefined) {
+  if (typeof opts.startAt !== "undefined") {
     this.startAt = opts.startAt;
     this.to(opts.startAt);
+  } else {
+    this.startAt = (this.degreeRange[1] - this.degreeRange[0]) / 2 + this.degreeRange[0];
   }
 
   // If "center" true set servo to 90deg
@@ -282,8 +295,8 @@ Servo.prototype.to = function(degrees, time, rate) {
       if (this.invert) {
         degrees = Fn.map(
           degrees,
-          0, 180,
-          180, 0
+          this.degreeRange[0], this.degreeRange[1],
+          this.degreeRange[1], this.degreeRange[0]
         );
       }
       

--- a/test/animation.js
+++ b/test/animation.js
@@ -219,7 +219,7 @@ exports["Animation -- Servo"] = {
 
     this.animation.target["@@render"](val);
     test.equal(testContext.servoWrite.args[1][0], 3);
-    test.equal(testContext.servoWrite.args[1][1], 80);
+    test.equal(testContext.servoWrite.args[1][1], 1404);
 
     test.done();
   },

--- a/test/board.js
+++ b/test/board.js
@@ -490,7 +490,7 @@ exports["Board"] = {
   },
 
   snapshot: function(test) {
-    test.expect(69);
+    test.expect(71);
 
     new Multi({
       controller: "BME280",
@@ -653,6 +653,8 @@ exports["Board"] = {
         pin: 10
       }, {
         deadband: [90, 90],
+        degreeRange: [ 0, 180 ],
+        pwmRange: [ 600, 2400 ],
         startAt: 90,
         value: null,
         position: -1,

--- a/test/esc.js
+++ b/test/esc.js
@@ -96,7 +96,7 @@ exports["ESC"] = {
     this.clock.tick(120);
     test.equal(this.servoWrite.callCount, 10);
     // (10 * 180 / 100) | 0 = 18
-    test.equal(this.servoWrite.lastCall.args[1], 18);
+    test.equal(this.servoWrite.lastCall.args[1], 729);
 
     this.servoWrite.reset();
 
@@ -104,15 +104,14 @@ exports["ESC"] = {
     this.clock.tick(10);
     test.equal(this.servoWrite.callCount, 1);
     // (9 * 180 / 100) = 16.2
-    test.equal(this.servoWrite.lastCall.args[1], 16.200000762939453);
+    test.equal(this.servoWrite.lastCall.args[1], 711);
 
     this.servoWrite.reset();
 
     this.esc.speed(12);
     this.clock.tick(30);
     test.equal(this.servoWrite.callCount, 3);
-    // (12 * 180 / 100) = 21.6
-    test.equal(this.servoWrite.lastCall.args[1], 21.6);
+    test.equal(this.servoWrite.lastCall.args[1], 766);
 
     test.done();
   },
@@ -463,7 +462,7 @@ exports["ESC - FORWARD_REVERSE"] = {
 
     test.ok(spy.calledOnce);
     test.equal(spy.getCall(0).args[0], 11);
-    test.equal(spy.getCall(0).args[1], 90);
+    test.equal(spy.getCall(0).args[1], 1472);
 
     spy.restore();
     test.done();

--- a/test/servo.collection.js
+++ b/test/servo.collection.js
@@ -95,12 +95,12 @@ exports["Servo.Collection"] = {
     }]);
 
     this.servos.to(180);
-    test.ok(this.servoWrite.calledWith(9, 180));
-    test.ok(this.servoWrite.calledWith(11, 180));
+    test.ok(this.servoWrite.calledWith(9, 2400));
+    test.ok(this.servoWrite.calledWith(11, 2400));
 
     this.servos.home();
-    test.ok(this.servoWrite.calledWith(9, 40));
-    test.ok(this.servoWrite.calledWith(11, 20));
+    test.ok(this.servoWrite.calledWith(9, 1000));
+    test.ok(this.servoWrite.calledWith(11, 800));
 
     test.done();
   },

--- a/test/servo.js
+++ b/test/servo.js
@@ -181,13 +181,13 @@ exports["Servo"] = {
     });
 
     this.servo.to(180);
-    test.ok(this.servoWrite.calledWith(11, 0));
+    test.ok(this.servoWrite.calledWith(11, 600));
 
     this.servo.to(135);
-    test.ok(this.servoWrite.calledWith(11, 45));
+    test.ok(this.servoWrite.calledWith(11, 1050));
 
     this.servo.to(90);
-    test.ok(this.servoWrite.calledWith(11, 90));
+    test.ok(this.servoWrite.calledWith(11, 1500));
 
     test.done();
   },
@@ -219,19 +219,19 @@ exports["Servo"] = {
     });
 
     this.servo.to(180);
-    test.ok(this.servoWrite.calledWith(11, 160));
+    test.ok(this.servoWrite.calledWith(11, 2200));
 
     this.servo.to(135);
-    test.ok(this.servoWrite.calledWith(11, 135));
+    test.ok(this.servoWrite.calledWith(11, 1950));
 
     this.servo.to(10);
-    test.ok(this.servoWrite.calledWith(11, 20));
+    test.ok(this.servoWrite.calledWith(11, 800));
 
     test.done();
   },
 
   rangeWithInvert: function(test) {
-    test.expect(6);
+    test.expect(3);
 
     this.servo = new Servo({
       pin: 11,
@@ -241,16 +241,13 @@ exports["Servo"] = {
     });
 
     this.servo.to(180);
-    test.ok(this.servoWrite.calledWith(11, 20));
-    test.equal(this.servo.value, 160);
+    test.ok(this.servoWrite.calledWith(11, 800));
 
     this.servo.to(135);
-    test.ok(this.servoWrite.calledWith(11, 45));
-    test.equal(this.servo.value, 135);
+    test.ok(this.servoWrite.calledWith(11, 1050));
 
     this.servo.to(10);
-    test.ok(this.servoWrite.calledWith(11, 150));
-    test.equal(this.servo.value, 30);
+    test.ok(this.servoWrite.calledWith(11, 2100));
 
     test.done();
   },
@@ -265,10 +262,10 @@ exports["Servo"] = {
     });
 
     this.servo.to(180);
-    test.ok(this.servoWrite.calledWith(11, 180));
+    test.ok(this.servoWrite.calledWith(11, 2400));
 
     this.servo.home();
-    test.ok(this.servoWrite.calledWith(11, 20));
+    test.ok(this.servoWrite.calledWith(11, 800));
 
     test.done();
   },
@@ -282,10 +279,10 @@ exports["Servo"] = {
     });
 
     this.servo.to(180);
-    test.ok(this.servoWrite.calledWith(11, 180));
+    test.ok(this.servoWrite.calledWith(11, 2400));
 
     this.servo.home();
-    test.ok(this.servoWrite.calledWith(11, 90));
+    test.ok(this.servoWrite.calledWith(11, 1500));
 
     test.done();
   },
@@ -300,16 +297,16 @@ exports["Servo"] = {
     });
 
     this.servo.to(180);
-    test.ok(this.servoWrite.calledWith(11, 170));
+    test.ok(this.servoWrite.calledWith(11, 2300));
 
     this.servo.to(135);
-    test.ok(this.servoWrite.calledWith(11, 125));
+    test.ok(this.servoWrite.calledWith(11, 1850));
 
     this.servo.to(10);
-    test.ok(this.servoWrite.calledWith(11, 0));
+    test.ok(this.servoWrite.calledWith(11, 600));
 
     this.servo.to(185);
-    test.ok(this.servoWrite.calledWith(11, 175));
+    test.ok(this.servoWrite.calledWith(11, 2350));
 
     test.equal(this.servo.value, 185);
 
@@ -317,7 +314,7 @@ exports["Servo"] = {
   },
 
   offsetWithInvert: function(test) {
-    test.expect(7);
+    test.expect(4);
 
     this.servo = new Servo({
       pin: 11,
@@ -327,16 +324,13 @@ exports["Servo"] = {
     });
 
     this.servo.to(180);
-    test.ok(this.servoWrite.calledWith(11, 10));
-    test.equal(this.servo.value, 180);
+    test.ok(this.servoWrite.calledWith(11, 700));
 
     this.servo.to(135);
-    test.ok(this.servoWrite.calledWith(11, 55));
-    test.equal(this.servo.value, 135);
+    test.ok(this.servoWrite.calledWith(11, 1150));
 
     this.servo.to(10);
-    test.ok(this.servoWrite.calledWith(11, 180));
-    test.equal(this.servo.value, 10);
+    test.ok(this.servoWrite.calledWith(11, 2400));
 
     test.equal(this.servo.value, 10);
     
@@ -344,7 +338,7 @@ exports["Servo"] = {
   },
 
   offsetWithRange: function(test) {
-    test.expect(6);
+    test.expect(3);
 
     this.servo = new Servo({
       pin: 11,
@@ -354,22 +348,19 @@ exports["Servo"] = {
     });
 
     this.servo.to(180);
-    test.ok(this.servoWrite.calledWith(11, 140));
-    test.equal(this.servo.value, 150);
+    test.ok(this.servoWrite.calledWith(11, 2000));
 
     this.servo.to(135);
-    test.ok(this.servoWrite.calledWith(11, 125));
-    test.equal(this.servo.value, 135);
+    test.ok(this.servoWrite.calledWith(11, 1850));
 
     this.servo.to(10);
-    test.ok(this.servoWrite.calledWith(11, 10));
-    test.equal(this.servo.value, 20);
+    test.ok(this.servoWrite.calledWith(11, 700));
 
     test.done();
   },
 
   offsetWithRangeAndInvert: function(test) {
-    test.expect(6);
+    test.expect(3);
 
     this.servo = new Servo({
       pin: 11,
@@ -380,16 +371,13 @@ exports["Servo"] = {
     });
 
     this.servo.to(180);
-    test.ok(this.servoWrite.calledWith(11, 40));
-    test.equal(this.servo.value, 150);
+    test.ok(this.servoWrite.calledWith(11, 1000));
 
     this.servo.to(135);
-    test.ok(this.servoWrite.calledWith(11, 55));
-    test.equal(this.servo.value, 135);
+    test.ok(this.servoWrite.calledWith(11, 1150));
 
     this.servo.to(10);
-    test.ok(this.servoWrite.calledWith(11, 170));
-    test.equal(this.servo.value, 20);
+    test.ok(this.servoWrite.calledWith(11, 2300));
 
     test.done();
   },
@@ -535,7 +523,7 @@ exports["Servo"] = {
 
     this.servo.to(138);
     test.equal(this.servoWrite.lastCall.args[0], 11);
-    test.equal(this.servoWrite.lastCall.args[1], 138);
+    test.equal(this.servoWrite.lastCall.args[1], 1980);
     test.equal(this.update.callCount, 1);
     test.equal(this.update.lastCall.args[0], 138);
     test.done();
@@ -1228,7 +1216,7 @@ exports["Servo - Continuous"] = {
 
   stopped: function(test) {
     test.expect(1);
-    test.ok(this.servoWrite.calledWith(11, 90));
+    test.ok(this.servoWrite.calledWith(11, 1500));
     test.done();
   },
 
@@ -1253,12 +1241,12 @@ exports["Servo - Continuous"] = {
     test.expect(2);
 
     this.a.cw();
-    test.ok(this.servoWrite.calledWith(11, 180));
+    test.ok(this.servoWrite.calledWith(11, 2400));
 
     this.servoWrite.restore();
 
     this.b.cw();
-    test.ok(this.servoWrite.calledWith(11, 180));
+    test.ok(this.servoWrite.calledWith(11, 2400));
 
 
     test.done();
@@ -1268,12 +1256,12 @@ exports["Servo - Continuous"] = {
     test.expect(2);
 
     this.a.ccw();
-    test.ok(this.servoWrite.calledWith(11, 0));
+    test.ok(this.servoWrite.calledWith(11, 600));
 
     this.servoWrite.restore();
 
     this.b.ccw();
-    test.ok(this.servoWrite.calledWith(11, 0));
+    test.ok(this.servoWrite.calledWith(11, 600));
 
 
     test.done();
@@ -1322,12 +1310,12 @@ exports["Servo - Continuous"] = {
     });
 
     this.continuousServo.cw();
-    test.ok(this.servoWrite.calledWith(5, 160));
+    test.ok(this.servoWrite.calledWith(5, 2200));
 
     this.servoWrite.reset();
 
     this.continuousServo.cw(0.5);
-    test.ok(this.servoWrite.calledWith(5, 128));
+    test.ok(this.servoWrite.calledWith(5, 1880));
 
     test.done();
   }

--- a/tpl/programs.json
+++ b/tpl/programs.json
@@ -294,6 +294,10 @@
         ]
       },
       {
+        "file": "servo-multi-turn.js",
+        "title": "Servo - Multi-Turn"
+      },
+      {
         "file": "servo-slider.js",
         "title": "Servo - Slider control"
       },


### PR DESCRIPTION
Previously #1387 

Servo values are now sent to io plug-ins in microseconds instead of degrees. This allows for better accuracy and different device ranges.

All servos now default to a PWM range of 600-2400 uS regardless of io-plugin being used (was a complete cluster before and couldn't be overridden on most platforms).

Adds new ```deviceRange``` property to servo opts that allows the user to specify the range of the servo. Defaults to 0-180°.

Changes the servo startAt value to be the center of the servo regardless of deviceRange unless otherwise specified by the user.

Adds servo multi-turn example

Updates PCA-9685 ```servoWrite()``` to allow values to be written in microseconds. This required updating esc as well.

Updates test.

Requires recent versions of most io-plugins (firmata.js was already fine):

imp-io v0.3.0 / Tyrion v0.0.3
particle-io v0.15.0 / VoodooSpark v4.1.0
tessel-io v1.2.0
raspi-io v8.1.1
beaglebone-io v3.0.0
linux-io v0.9.2

