### PR TITLE
Add missing commas in stepper comments

### DIFF
--- a/lib/stepper.js
+++ b/lib/stepper.js
@@ -56,7 +56,7 @@ function isSupported(io) {
  *
  *
  * five.Stepper({
- *  type: five.Stepper.TYPE.DRIVER
+ *  type: five.Stepper.TYPE.DRIVER,
  *  stepsPerRev: number,
  *  pins: {
  *    step: number,
@@ -65,13 +65,13 @@ function isSupported(io) {
  * });
  *
  * five.Stepper({
- *  type: five.Stepper.TYPE.DRIVER
+ *  type: five.Stepper.TYPE.DRIVER,
  *  stepsPerRev: number,
  *  pins: [ step, dir ]
  * });
  *
  * five.Stepper({
- *  type: five.Stepper.TYPE.TWO_WIRE
+ *  type: five.Stepper.TYPE.TWO_WIRE,
  *  stepsPerRev: number,
  *  pins: {
  *    motor1: number,
@@ -80,13 +80,13 @@ function isSupported(io) {
  * });
  *
  * five.Stepper({
- *  type: five.Stepper.TYPE.TWO_WIRE
+ *  type: five.Stepper.TYPE.TWO_WIRE,
  *  stepsPerRev: number,
  *  pins: [ motor1, motor2 ]
  * });
  *
  * five.Stepper({
- *  type: five.Stepper.TYPE.FOUR_WIRE
+ *  type: five.Stepper.TYPE.FOUR_WIRE,
  *  stepsPerRev: number,
  *  pins: {
  *    motor1: number,
@@ -97,7 +97,7 @@ function isSupported(io) {
  * });
  *
  * five.Stepper({
- *  type: five.Stepper.TYPE.FOUR_WIRE
+ *  type: five.Stepper.TYPE.FOUR_WIRE,
  *  stepsPerRev: number,
  *  pins: [ motor1, motor2, motor3, motor4 ]
  * });


### PR DESCRIPTION
Added missing commas to some of the examples in the comments. For example, I changed this:

```js
five.Stepper({
  type: five.Stepper.TYPE.FOUR_WIRE
  stepsPerRev: number,
```

to this

```js
five.Stepper({
  type: five.Stepper.TYPE.FOUR_WIRE,
  stepsPerRev: number,
```