### PR TITLE
Fix for #1499

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -618,7 +618,7 @@ Collection.installMethodForwarding(
  */
 Servos.prototype[Animation.normalize] = function(keyFrameSet) {
   return keyFrameSet.map(function(keyFrames, index) {
-    if (keyFrames !== null) {
+    if (keyFrames !== null && Array.isArray(keyFrames)) {
       var servo = this[index];
 
       // If servo is a servoArray then user servo[0] for default values
@@ -642,8 +642,12 @@ Servos.prototype[Animation.normalize] = function(keyFrameSet) {
           };
         }
       }
-
       return this[index][Animation.normalize](keyFrames);
+    }
+
+    if (keyFrames && typeof keyFrames.degrees === "number") {
+      keyFrames.value = keyFrames.degrees;
+      delete keyFrames.degrees;
     }
     return keyFrames;
   }, this);

--- a/test/extended/servo.js
+++ b/test/extended/servo.js
@@ -67,7 +67,7 @@ exports["Servo"] = {
 
     this.servo.on("move:complete", function() {
       test.equal(this.servo.position, 0);
-      test.ok(this.servoWrite.callCount === 101);
+      test.ok(this.servoWrite.callCount === 101, "Expected 101 calls to servoWrite. Saw " + this.servoWrite.callCount);
       test.done();
     }.bind(this));
   },
@@ -144,7 +144,7 @@ exports["Servo"] = {
 
     this.servo.on("move:complete", function() {
       test.equal(this.servo.position, 0);
-      test.ok(this.servoWrite.callCount === 101);
+      test.ok(this.servoWrite.callCount === 101, "Expected 101 calls to servoWrite. Saw " + this.servoWrite.callCount);
       test.done();
     }.bind(this));
   },
@@ -163,7 +163,7 @@ exports["Servo"] = {
 
     this.servo.on("move:complete", function() {
       test.equal(this.servo.position, 180);
-      test.ok(this.servoWrite.callCount === 101);
+      test.ok(this.servoWrite.callCount === 101, "Expected 101 calls to servoWrite. Saw " + this.servoWrite.callCount);
       test.done();
     }.bind(this));
   },
@@ -217,7 +217,7 @@ exports["Servo"] = {
 
     this.servo.on("move:complete", function() {
       test.equal(this.servo.value, 80);
-      test.equal(this.servoWrite.lastCall.args[1], 70);
+      test.equal(this.servoWrite.lastCall.args[1], 1300);
       test.done();
     }.bind(this));
     
@@ -237,7 +237,7 @@ exports["Servo"] = {
 
     this.servo.on("move:complete", function() {
       test.equal(this.servo.value, 80);
-      test.equal(this.servoWrite.lastCall.args[1], 110);
+      test.equal(this.servoWrite.lastCall.args[1], 1700);
       test.done();
     }.bind(this));
     

--- a/test/servo.collection.js
+++ b/test/servo.collection.js
@@ -21,6 +21,11 @@ exports["Servo.Collection"] = {
       pin: 9,
       board: this.board
     });
+    
+    this.d = new Servo({
+      pin: 11,
+      board: this.board
+    });
 
     this.spies = [
       "to", "stop"
@@ -127,6 +132,54 @@ exports["Servo.Collection"] = {
     test.done();
   },
 
+  "Animation.normalize-nested": function(test) {
+    test.expect(1);
+
+    var group1 = new Servos([
+      this.a, this.b
+    ]);
+
+    var group2 = new Servos([
+      this.c, this.d
+    ]);
+
+    var bothGroups = new Servos([
+      group1, group2
+    ]);
+
+    var normalized = bothGroups[Animation.normalize]([
+      [
+        [
+          null,
+          10,
+        ]
+      ],
+      [
+        [
+          null,
+          20,
+        ]
+      ]
+    ]);
+
+    test.deepEqual(normalized, [
+      [ 
+        [ 
+          { value: 90, easing: "linear" }, 
+          { step: 10, easing: "linear" }
+        ]
+      ],
+      [ 
+        [ 
+          { value: 90, easing: "linear" },
+          { step: 20, easing: "linear" }
+        ]
+      ]
+    ]);
+
+    test.done();
+  },
+  
   "Animation.normalize": function(test) {
     test.expect(3);
 

--- a/test/servo.js
+++ b/test/servo.js
@@ -1105,6 +1105,54 @@ exports["Servo"] = {
     test.done();
   },
 
+  "Animation.normalize (degrees instead of value)": function(test) {
+    test.expect(1);
+
+    this.servo = new Servo({
+      board: this.board,
+      pin: 11,
+    });
+
+    var normalized = this.servo[Animation.normalize]([
+      null,
+      {degrees: 0},
+    ]);
+
+    test.equal(normalized[1].value, 0);
+
+    test.done();
+  },
+
+  "Animation.normalize (nested degrees instead of value)": function(test) {
+    test.expect(2);
+
+    this.servos = new Servos([
+      {
+        board: this.board,
+        pin: 11,
+      }, {
+        board: this.board,
+        pin: 12,
+      }
+    ]);
+
+    var normalized = this.servos[Animation.normalize]([
+      [
+        null,
+        {degrees: 0}
+      ],
+      [
+        null,
+        {degrees: 180}
+      ],
+    ]);
+
+    test.equal(normalized[0][1].value, 0);
+    test.equal(normalized[1][1].value, 180);
+
+    test.done();
+  },
+
   "Animation.render": function(test) {
     test.expect(2);
 


### PR DESCRIPTION
If an array of keyFrames are passed to Servos, those keyFrames should be used as values for the whole collection and should not be normalized as a keyFrameSet.