### PR TITLE
Remove useless var assignment

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -781,7 +781,7 @@ Board.mount = function(arg) {
   // found or not available
   if (typeof index === "number") {
     hardware = boards[index];
-    return hardware && hardware || null;
+    return hardware ? hardware : null;
   }
 
   // If no arg specified and hardware instances

--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -52,10 +52,8 @@ var Controllers = {
       value: function(opts, pinValue) {
 
         var state = priv.get(this);
-        var isFirmata = true;
+        var isFirmata = Pins.isFirmata(this);
         var defaultLed;
-
-        isFirmata = Pins.isFirmata(this);
 
         if (isFirmata && typeof pinValue === "string" && pinValue[0] === "A") {
           pinValue = this.io.analogPins[+pinValue.slice(1)];


### PR DESCRIPTION
This variable is assigned twice in a row so I removed the first assignment.
I also decided to used the ternary operator to make the code more readable when returning the hardware.