### PR TITLE
Use correct port for Potentiometer example

### DIFF
--- a/docs/potentiometer.md
+++ b/docs/potentiometer.md
@@ -38,7 +38,7 @@ board.on("ready", function() {
 
   // Create a new `potentiometer` hardware instance.
   potentiometer = new five.Sensor({
-    pin: "A2",
+    pin: "A3",
     freq: 250
   });
 

--- a/eg/potentiometer.js
+++ b/eg/potentiometer.js
@@ -7,7 +7,7 @@ board.on("ready", function() {
 
   // Create a new `potentiometer` hardware instance.
   potentiometer = new five.Sensor({
-    pin: "A2",
+    pin: "A3",
     freq: 250
   });
 


### PR DESCRIPTION
Currently, the schema uses A3 but the code uses A2.

I've updated the example to use A3.