### PR TITLE
Feature proposal: Possibility to set default pin modes and pin values to expanders

### DIFF
--- a/lib/expander.js
+++ b/lib/expander.js
@@ -382,8 +382,10 @@ var Controllers = {
             analogChannel: 127
           });
 
-          this.pinMode(i, this.MODES.OUTPUT);
-          this.digitalWrite(i, this.LOW);
+          var mode = opts.defaultPinMode || this.MODES.OUTPUT;
+          var value = opts.defaultPinValue || this.LOW;
+
+          this.initializePin(i, mode, value);
         }
 
         this.name = "PCF8574";
@@ -398,6 +400,33 @@ var Controllers = {
         return pin;
       }
     },
+    initializePin: {
+      value: function(pin,mode,value) {
+        var state = priv.get(this);
+        var pinIndex = pin;
+        var port = state.port;
+        var ddr = state.ddr;
+        var pins = state.pins;
+
+        if (mode === this.MODES.INPUT) {
+          ddr &= ~(1 << pin);
+        } else {
+          ddr |= (1 << pin);
+        }
+        if (value) {
+          port |= 1 << pin;
+        } else {
+          port &= ~(1 << pin);
+        }
+
+        this.pins[pinIndex].mode = mode;
+
+        state.port = port;
+        state.ddr = ddr;
+
+        this.io.i2cWrite(this.address, (pins & ~ddr) | port);
+      }
+    },
     pinMode: {
       value: function(pin, mode) {
         var state = priv.get(this);
@@ -408,10 +437,10 @@ var Controllers = {
 
         if (mode === this.MODES.INPUT) {
           ddr &= ~(1 << pin);
-          port &= ~(1 << pin);
+          //port &= ~(1 << pin);
         } else {
           ddr |= (1 << pin);
-          port &= ~(1 << pin);
+          //port &= ~(1 << pin);
         }
 
         this.pins[pinIndex].mode = mode;


### PR DESCRIPTION
Hi Johnny-five team,

for a project I needed a possibility to change the initial pin mode and pin value for the PCF8574. The PCF8574 sets default all pins to INPUT and HIGH (from data sheet). In johnny five all pins are set in the initialisation to OUTPUT and LOW. Additionally the setMode function also sets the pin to LOW. Because the IO Pins from the PCF8574 are connected to another microcontroller these short changes cause problems.

So my idea is to add default parameters to the Expander function to add the possibility to handle the initial problems. But I also see that this problem is not as easy because keeping things consistent is related (in the broadest sense) to the arduino firmata issue https://github.com/firmata/arduino/issues/308 . 

For the second problem one possible solution is modifying the setMode function, but this is also a big consistency issue. Another idea is to add additional setMode-functions or an additional parameter to setMode to handle this.

For a better understanding I opened this as a pull request with my hacked variant of johnny five.

best regards,

Daniel