### PR TITLE
Docs: update ESC examples with newer javascript syntax

### DIFF
--- a/docs/esc-PCA9685.md
+++ b/docs/esc-PCA9685.md
@@ -29,11 +29,10 @@ node eg/esc-PCA9685.js
 
 
 ```javascript
-const {Board, ESC, Sensor} = require("johnny-five");
+const { Board, ESC, Sensor } = require("johnny-five");
 const board = new Board();
 
-board.on("ready", function() {
-
+board.on("ready", () => {
   const esc = new ESC({
     controller: "PCA9685",
     device: "FORWARD",

--- a/docs/esc-array.md
+++ b/docs/esc-array.md
@@ -29,22 +29,17 @@ node eg/esc-array.js
 
 
 ```javascript
-var five = require("johnny-five");
-var board = new five.Board();
+const {Board, ESC} = require('johnny-five');
+const board = new Board();
 
-board.on("ready", function() {
-
-  var escs = new five.ESCs([9, 10]);
+board.on('ready', () => {
+  const escs = new ESC.Collection([9, 10]);
 
   // Set the motors to their max speed
-  // This could be dangerous
+  // This might be dangerous ¯\_(ツ)_/¯
   escs.throttle(100);
 
-  board.wait(2000, function() {
-    // Set the motors to the min speed (stopped)
-    escs.brake();
-  });
-
+  board.wait(2000, esc.brake);
 });
 
 ```

--- a/docs/esc-bidirectional-forward-reverse.md
+++ b/docs/esc-bidirectional-forward-reverse.md
@@ -29,26 +29,24 @@ node eg/esc-bidirectional-forward-reverse.js
 
 
 ```javascript
-var five = require("../");
-var board = new five.Board();
+const {Board, Button, ESC, Sensor} = require('johnny-five');
+const board = new Board();
 
-board.on("ready", function() {
-  var start = Date.now();
-  var esc = new five.ESC({
-    device: "FORWARD_REVERSE",
+board.on('ready', () => {
+  const start = Date.now();
+  const esc = new ESC({
+    device: 'FORWARD_REVERSE',
     neutral: 50,
-    pin: 11
+    pin: 11,
   });
-  var throttle = new five.Sensor("A0");
-  var brake = new five.Button(4);
+  const throttle = new Sensor('A0');
+  const brake = new Button(4);
 
-  brake.on("press", function() {
-    esc.brake();
-  });
+  brake.on('press', esc.brake);
 
-  throttle.scale(0, 100).on("change", function() {
+  throttle.scale(0, 100).on('change', () => {
     // 2 Seconds for arming.
-    if (Date.now() - start < 2e3) {
+    if (Date.now() - start < 2000) {
       return;
     }
 

--- a/docs/esc-bidirectional.md
+++ b/docs/esc-bidirectional.md
@@ -29,10 +29,10 @@ node eg/esc-bidirectional.js
 
 
 ```javascript
-const {Board, Button, ESC, Sensor} = require("../");
+const { Board, Button, ESC, Sensor } = require("johnny-five");
 const board = new Board();
 
-board.on("ready", function() {
+board.on("ready", () => {
   const esc = new ESC({
     device: "FORWARD_REVERSE",
     pin: 11
@@ -40,9 +40,7 @@ board.on("ready", function() {
   const throttle = new Sensor("A0");
   const brake = new Button(4);
 
-  brake.on("press", () => {
-    esc.brake();
-  });
+  brake.on("press", esc.brake);
 
   throttle.on("change", () => {
     esc.throttle(throttle.scaleTo(esc.pwmRange));

--- a/docs/esc-dualshock.md
+++ b/docs/esc-dualshock.md
@@ -29,53 +29,52 @@ node eg/esc-dualshock.js
 
 
 ```javascript
-var five = require("../lib/johnny-five.js");
-var dualShock = require("dualshock-controller");
+const {Board, ESC, Fn} = require('johnny-five');
+const dualShock = require('dualshock-controller');
 
-var board = new five.Board();
-var controller = dualShock({
-  config: "dualShock3",
-  analogStickSmoothing: false
+const board = new Board();
+const controller = dualShock({
+  config: 'dualShock3',
+  analogStickSmoothing: false,
 });
 
-board.on("ready", function() {
+board.on('ready', () => {
+  const esc = new ESC(9);
+  let speed = 0;
+  let last = null;
 
-  var esc = new five.ESC(9);
-  var speed = 0;
-  var last = null;
-
-  controller.on("connected", function() {
+  controller.on('connected', () => {
     controller.isConnected = true;
   });
 
-  controller.on("dpadUp:press", function() {
-    if (last !== "up") {
+  controller.on('dpadUp:press', () => {
+    if (last !== 'up') {
       speed = 0;
     } else {
       speed += 1;
     }
     esc.throttle(esc.neutral + speed);
-    last = "up"
+    last = 'up';
   });
 
-  controller.on("dpadDown:press", function() {
-    if (last !== "down") {
+  controller.on('dpadDown:press', () => {
+    if (last !== 'down') {
       speed = 0;
     } else {
       speed += 1;
     }
     esc.throttle(esc.neutral - speed);
-    last = "down"
+    last = 'down';
   });
 
-  controller.on("circle:press", function() {
+  controller.on('circle:press', () => {
     last = null;
     speed = 0;
     esc.brake();
   });
 
-  controller.on("right:move", function(position) {
-    var y = five.Fn.scale(position.y, 255, 0, 0, 180) | 0;
+  controller.on('right:move', position => {
+    const y = Fn.scale(position.y, 255, 0, 0, 180) | 0;
 
     if (y > 100) {
       // from the deadzone and up
@@ -85,7 +84,6 @@ board.on("ready", function() {
 
   controller.connect();
 });
-
 
 // Brushless motor breadboard diagram originally published here:
 // http://robotic-controls.com/learn/projects/dji-esc-and-brushless-motor

--- a/docs/esc-keypress.md
+++ b/docs/esc-keypress.md
@@ -29,15 +29,15 @@ node eg/esc-keypress.js
 
 
 ```javascript
-const {Board, ESC, Fn, Led} = require("johnny-five");
+const { Board, ESC, Fn, Led } = require("johnny-five");
 const keypress = require("keypress");
 const board = new Board();
 
-board.on("ready", function() {
+board.on("ready", () => {
   const led = new Led(13);
   const esc = new ESC({
     device: "FORWARD_REVERSE",
-    pin: 11,
+    pin: 11
   });
   let speed = 0;
   let last = null;
@@ -60,9 +60,8 @@ board.on("ready", function() {
           } else {
             speed += 1;
 
-            change = key.name === "up" ?
-              esc.neutral + speed :
-              esc.neutral - speed;
+            change =
+              key.name === "up" ? esc.neutral + speed : esc.neutral - speed;
           }
           last = key.name;
         }

--- a/eg/esc-PCA9685.js
+++ b/eg/esc-PCA9685.js
@@ -1,8 +1,7 @@
-const {Board, ESC, Sensor} = require("../lib/johnny-five.js");
+const { Board, ESC, Sensor } = require("../lib/johnny-five.js");
 const board = new Board();
 
-board.on("ready", function() {
-
+board.on("ready", () => {
   const esc = new ESC({
     controller: "PCA9685",
     device: "FORWARD",

--- a/eg/esc-array.js
+++ b/eg/esc-array.js
@@ -1,13 +1,12 @@
-const {Board, ESC} = require("../lib/johnny-five.js");
+const { Board, ESC } = require("../lib/johnny-five.js");
 const board = new Board();
 
-board.on("ready", function() {
-
+board.on("ready", () => {
   const escs = new ESC.Collection([9, 10]);
 
   // Set the motors to their max speed
   // This might be dangerous ¯\_(ツ)_/¯
   escs.throttle(100);
 
-  board.wait(2000, () => escs.brake());
+  board.wait(2000, escs.brake);
 });

--- a/eg/esc-bidirectional-forward-reverse.js
+++ b/eg/esc-bidirectional-forward-reverse.js
@@ -1,23 +1,21 @@
-var five = require('../');
-var board = new five.Board();
+const { Board, Button, ESC, Sensor } = require("../lib/johnny-five");
+const board = new Board();
 
-board.on('ready', function() {
-  var start = Date.now();
-  var esc = new five.ESC({
-    device: 'FORWARD_REVERSE',
+board.on("ready", () => {
+  const start = Date.now();
+  const esc = new ESC({
+    device: "FORWARD_REVERSE",
     neutral: 50,
-    pin: 11,
+    pin: 11
   });
-  var throttle = new five.Sensor('A0');
-  var brake = new five.Button(4);
+  const throttle = new Sensor("A0");
+  const brake = new Button(4);
 
-  brake.on('press', function() {
-    esc.brake();
-  });
+  brake.on("press", esc.brake);
 
-  throttle.scale(0, 100).on('change', function() {
+  throttle.scale(0, 100).on("change", () => {
     // 2 Seconds for arming.
-    if (Date.now() - start < 2e3) {
+    if (Date.now() - start < 2000) {
       return;
     }
 

--- a/eg/esc-bidirectional.js
+++ b/eg/esc-bidirectional.js
@@ -1,7 +1,7 @@
-const {Board, Button, ESC, Sensor} = require("../");
+const { Board, Button, ESC, Sensor } = require("../lib/johnny-five");
 const board = new Board();
 
-board.on("ready", function() {
+board.on("ready", () => {
   const esc = new ESC({
     device: "FORWARD_REVERSE",
     pin: 11
@@ -9,9 +9,7 @@ board.on("ready", function() {
   const throttle = new Sensor("A0");
   const brake = new Button(4);
 
-  brake.on("press", () => {
-    esc.brake();
-  });
+  brake.on("press", esc.brake);
 
   throttle.on("change", () => {
     esc.throttle(throttle.scaleTo(esc.pwmRange));

--- a/eg/esc-dualshock.js
+++ b/eg/esc-dualshock.js
@@ -1,60 +1,58 @@
-var five = require("../lib/johnny-five.js");
-var dualShock = require("dualshock-controller");
+const { Board, ESC, Fn } = require("../lib/johnny-five.js");
+const dualShock = require("dualshock-controller");
 
-var board = new five.Board();
-var controller = dualShock({
+const board = new Board();
+const controller = dualShock({
   config: "dualShock3",
   analogStickSmoothing: false
 });
 
-board.on("ready", function() {
+board.on("ready", () => {
+  const esc = new ESC(9);
+  let speed = 0;
+  let last = null;
 
-  var esc = new five.ESC(9);
-  var speed = 0;
-  var last = null;
-
-  controller.on("connected", function() {
+  controller.on("connected", () => {
     controller.isConnected = true;
   });
 
-  controller.on("dpadUp:press", function() {
+  controller.on("dpadUp:press", () => {
     if (last !== "up") {
       speed = 0;
     } else {
       speed += 1;
     }
     esc.throttle(esc.neutral + speed);
-    last = "up"
+    last = "up";
   });
 
-  controller.on("dpadDown:press", function() {
+  controller.on("dpadDown:press", () => {
     if (last !== "down") {
       speed = 0;
     } else {
       speed += 1;
     }
     esc.throttle(esc.neutral - speed);
-    last = "down"
+    last = "down";
   });
 
-  controller.on("circle:press", function() {
+  controller.on("circle:press", () => {
     last = null;
     speed = 0;
     esc.brake();
   });
 
-  controller.on("right:move", function(position) {
-    var y = five.Fn.scale(position.y, 255, 0, 0, 180) | 0;
+  controller.on("right:move", position => {
+    const y = Fn.scale(position.y, 255, 0, 0, 180) | 0;
 
     if (y > 100) {
       // from the deadzone and up
-      esc.throttle(scale(y, 100, 180, 0, 100));
+      esc.throttle(Fn.scale(y, 100, 180, 0, 100));
     }
   });
 
   controller.connect();
 });
-
 
 // Brushless motor breadboard diagram originally published here:
 // http://robotic-controls.com/learn/projects/dji-esc-and-brushless-motor

--- a/eg/esc-keypress.js
+++ b/eg/esc-keypress.js
@@ -1,12 +1,12 @@
-const {Board, ESC, Fn, Led} = require("../lib/johnny-five.js");
+const { Board, ESC, Fn, Led } = require("../lib/johnny-five.js");
 const keypress = require("keypress");
 const board = new Board();
 
-board.on("ready", function() {
+board.on("ready", () => {
   const led = new Led(13);
   const esc = new ESC({
     device: "FORWARD_REVERSE",
-    pin: 11,
+    pin: 11
   });
   let speed = 0;
   let last = null;
@@ -29,9 +29,8 @@ board.on("ready", function() {
           } else {
             speed += 1;
 
-            change = key.name === "up" ?
-              esc.neutral + speed :
-              esc.neutral - speed;
+            change =
+              key.name === "up" ? esc.neutral + speed : esc.neutral - speed;
           }
           last = key.name;
         }


### PR DESCRIPTION
Updating the ESC examples that I've been looking at a bunch while preparing for Nodeboats at JSConf. Related to task discussed at recent collaborators mini-summit: https://github.com/rwaldron/johnny-five/issues/1588#issuecomment-521467213

The double-quote -> single-quote conversions were automated by my editor, so happy to change those back if needed. 