### PR TITLE
GitHub based website build system

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -1,0 +1,45 @@
+name: Build Website
+
+on:
+  push:
+    branches:
+      - master
+  gollum: []
+
+jobs:
+  build:
+    name: Build Website
+    runs-on: ubuntu-latest
+    steps:
+    - name: 🚀 Installing Node 8
+      uses: actions/setup-node@v1
+      with:
+        node-version: '8.x'
+    - name: 💎 Installing Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+    - name: ⚡️ Install SASS
+      run: gem install sass
+    - name: 🤖⚡️🤖 Clone Johnny-Five.io Repo
+      run: git clone https://github.com/nodebots/johnny-five.io.git ${GITHUB_WORKSPACE}
+    - name: 📓 Install
+      run: |
+        npm ci
+    - name: 🛠 Build
+      run: |
+        npm run build
+    - name: 🚄 Push to gh-pages
+      env:
+        DEPLOY_BRANCH: gh-pages
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd public
+        echo -n 'Files to Commit:' && find . -type f | wc -l
+        git init
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git add .
+        git commit -m 'website build'
+        git push --force https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git master:$DEPLOY_BRANCH
+        echo '👍 GREAT SUCCESS!'


### PR DESCRIPTION
This Hosts and Builds the johnny-five.io site with github pages and actions.

This would replace our current setup with one that’s completely GitHub based. It uses GitHub pages with custom domains and https enabled for hosting, and GitHub actions to build the site automatically whenever the code or wiki changes.

This is in response to a few people commenting they found updating the website difficult, this exposes the build system and logs to all contributors.

On a commit to master or update to the wiki
- clone nodebots/johnny-five.io
- npm ci && npm build
- force push the `public` folder to the `gh-pages` branch of rwaldron/johnny-five

The build can be triggered manually be rerunning the last job in the actions tab on GitHub.

This requires the beta (public release in November) of GitHub actions. If you aren’t already in it you can request access. (I got it for the `nodebots` org btw.)

You can see a demo (from a fork) here (assets aren’t configured to work without a custom domain which I didn’t setup for this demo): 
http://reconbot.github.io/johnny-five/

You can see all the logs in the actions tab of the repo.
https://github.com/reconbot/johnny-five/actions

And of course Screenshots of what it looks like to use it!
<img width="1427" alt="Screen Shot 2019-08-16 at 12 59 27 PM" src="https://user-images.githubusercontent.com/25966/63195367-66675a00-c040-11e9-9002-c96432ce2594.png">
<img width="1433" alt="Screen Shot 2019-08-16 at 12 59 39 PM" src="https://user-images.githubusercontent.com/25966/63195369-69624a80-c040-11e9-8955-91bfc8eca393.png">
<img width="763" alt="Screen Shot 2019-08-16 at 12 59 50 PM" src="https://user-images.githubusercontent.com/25966/63195377-6c5d3b00-c040-11e9-9c23-ce33d819c91e.png">
<img width="597" alt="Screen Shot 2019-08-16 at 1 00 10 PM" src="https://user-images.githubusercontent.com/25966/63195388-7121ef00-c040-11e9-922d-654d4f6590db.png">

TODO
- Discuss if we want the `golum` (wiki updates) hook, this has potential for abuse as anyone can edit the wiki. We can always trigger a build manually or move the wiki files into the repo.
- Update johnny-five.io to have the right asset configuration for github pages
- Have @rwaldron request access to the github beta actions program https://github.com/features/actions (takes a few days)
