### PR TITLE
Examples: update light syntax

### DIFF
--- a/docs/grove-light-sensor-edison.md
+++ b/docs/grove-light-sensor-edison.md
@@ -20,17 +20,17 @@ node eg/grove-light-sensor-edison.js
 
 
 ```javascript
-var five = require("johnny-five");
-var Edison = require("edison-io");
-var board = new five.Board({
+const five = require("johnny-five");
+const Edison = require("edison-io");
+const board = new five.Board({
   io: new Edison()
 });
 
-board.on("ready", function() {
+board.on("ready", () => {
 
   // Plug the Grove TSL2561 Light sensor module
   // into an I2C jack
-  var light = new five.Light({
+  const light = new five.Light({
     controller: "TSL2561"
   });
 

--- a/docs/light-ambient-BH1750.md
+++ b/docs/light-ambient-BH1750.md
@@ -29,16 +29,16 @@ node eg/light-ambient-BH1750.js
 
 
 ```javascript
-var five = require("johnny-five");
-var board = new five.Board();
+const { Board, Light } = require("johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var light = new five.Light({
+board.on("ready", () => {
+  const light = new Light({
     controller: "BH1750",
   });
 
-  light.on("data", function() {
-    console.log("Lux: ", this.lux);
+  light.on("data", (data) => {
+    console.log("Lux: ", data.lux);
   });
 });
 

--- a/docs/light-ambient-EVS_EV3.md
+++ b/docs/light-ambient-EVS_EV3.md
@@ -18,17 +18,17 @@ node eg/light-ambient-EVS_EV3.js
 
 
 ```javascript
-var five = require("johnny-five");
-var board = new five.Board();
+const { Board, Light } = require("johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var light = new five.Light({
+board.on("ready", () => {
+  const light = new Light({
     controller: "EVS_EV3",
     pin: "BAS1"
   });
 
-  light.on("change", function() {
-    console.log("Ambient Light Level: ", this.level);
+  light.on("change", (data) => {
+    console.log("Ambient Light Level: ", data.level);
   });
 });
 

--- a/docs/light-ambient-EVS_NXT.md
+++ b/docs/light-ambient-EVS_NXT.md
@@ -18,17 +18,17 @@ node eg/light-ambient-EVS_NXT.js
 
 
 ```javascript
-var five = require("johnny-five");
-var board = new five.Board();
+const { Board, Light } = require("johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var light = new five.Light({
+board.on("ready", () => {
+  const light = new Light({
     controller: "EVS_NXT",
     pin: "BAS2"
   });
 
-  light.on("change", function() {
-    console.log("Ambient Light Level: ", this.level);
+  light.on("change", (data) => {
+    console.log("Ambient Light Level: ", data.level);
   });
 });
 

--- a/docs/light-ambient-TSL2561.md
+++ b/docs/light-ambient-TSL2561.md
@@ -29,16 +29,16 @@ node eg/light-ambient-TSL2561.js
 
 
 ```javascript
-var five = require("johnny-five");
-var board = new five.Board();
+const { Board, Light } = require("johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var light = new five.Light({
+board.on("ready", () => {
+  const light = new Light({
     controller: "TSL2561",
   });
 
-  light.on("data", function() {
-    console.log("Lux: ", this.lux);
+  light.on("data", (data) => {
+    console.log("Lux: ", data.lux);
   });
 });
 

--- a/docs/light-reflected-EVS_EV3.md
+++ b/docs/light-reflected-EVS_EV3.md
@@ -18,18 +18,18 @@ node eg/light-reflected-EVS_EV3.js
 
 
 ```javascript
-var five = require("johnny-five");
-var board = new five.Board();
+const { Board, Light } = require("johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var reflect = new five.Light({
+board.on("ready", () => {
+  const reflect = new Light({
     controller: "EVS_EV3",
     pin: "BAS1",
     mode: "reflected"
   });
 
-  reflect.on("change", function() {
-    console.log("Light Reflection Level: ", this.level);
+  reflect.on("change", (data) => {
+    console.log("Light Reflection Level: ", data.level);
   });
 });
 

--- a/docs/light-reflected-EVS_NXT.md
+++ b/docs/light-reflected-EVS_NXT.md
@@ -18,18 +18,18 @@ node eg/light-reflected-EVS_NXT.js
 
 
 ```javascript
-var five = require("johnny-five");
-var board = new five.Board();
+const { Board, Light } = require("johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var reflect = new five.Light({
+board.on("ready", () => {
+  const reflect = new Light({
     controller: "EVS_NXT",
     pin: "BBS1",
     mode: "reflected"
   });
 
-  reflect.on("change", function() {
-    console.log("Light Reflection Level: ", this.level);
+  reflect.on("change", (data) => {
+    console.log("Light Reflection Level: ", data.level);
   });
 });
 

--- a/eg/arduino-starter-kit/light-theremin.js
+++ b/eg/arduino-starter-kit/light-theremin.js
@@ -1,22 +1,22 @@
-var five = require("johnny-five");
-var Edison = require("edison-io");
-var board = new five.Board({
+const five = require("johnny-five");
+const Edison = require("edison-io");
+const board = new five.Board({
   io: new Edison()
 });
 
-board.on("ready", function() {
-  var sensor = new five.Sensor({
+board.on("ready", () => {
+  const sensor = new five.Sensor({
     pin: "A0",
     freq: 30
   });
-  var piezo = new five.Piezo(8);
-  var min = 1024;
-  var max = 0;
+  const piezo = new five.Piezo(8);
+  let min = 1024;
+  let max = 0;
 
-  sensor.on("data", function() {
-    min = Math.min(min, this.value);
-    max = Math.max(max, this.value);
-    var pitch = five.Fn.scale(this.value, min, max, 50, 4000);
+  sensor.on("data", (data) => {
+    min = Math.min(min, data.value);
+    max = Math.max(max, data.value);
+    const pitch = five.Fn.scale(data.value, min, max, 50, 4000);
     piezo.frequency(pitch, 20);
     console.log(min, max, pitch);
   });

--- a/eg/grove-light-sensor-edison.js
+++ b/eg/grove-light-sensor-edison.js
@@ -1,14 +1,14 @@
-var five = require("../lib/johnny-five");
-var Edison = require("edison-io");
-var board = new five.Board({
+const five = require("../lib/johnny-five");
+const Edison = require("edison-io");
+const board = new five.Board({
   io: new Edison()
 });
 
-board.on("ready", function() {
+board.on("ready", () => {
 
   // Plug the Grove TSL2561 Light sensor module
   // into an I2C jack
-  var light = new five.Light({
+  const light = new five.Light({
     controller: "TSL2561"
   });
 

--- a/eg/light-ambient-BH1750.js
+++ b/eg/light-ambient-BH1750.js
@@ -1,12 +1,12 @@
-var five = require("../lib/johnny-five.js");
-var board = new five.Board();
+const { Board, Light } = require("../lib/johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var light = new five.Light({
+board.on("ready", () => {
+  const light = new Light({
     controller: "BH1750",
   });
 
-  light.on("data", function() {
-    console.log("Lux: ", this.lux);
+  light.on("data", (data) => {
+    console.log("Lux: ", data.lux);
   });
 });

--- a/eg/light-ambient-EVS_EV3.js
+++ b/eg/light-ambient-EVS_EV3.js
@@ -1,13 +1,13 @@
-var five = require("../lib/johnny-five.js");
-var board = new five.Board();
+const { Board, Light } = require("../lib/johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var light = new five.Light({
+board.on("ready", () => {
+  const light = new Light({
     controller: "EVS_EV3",
     pin: "BAS1"
   });
 
-  light.on("change", function() {
-    console.log("Ambient Light Level: ", this.level);
+  light.on("change", (data) => {
+    console.log("Ambient Light Level: ", data.level);
   });
 });

--- a/eg/light-ambient-EVS_NXT.js
+++ b/eg/light-ambient-EVS_NXT.js
@@ -1,13 +1,13 @@
-var five = require("../lib/johnny-five.js");
-var board = new five.Board();
+const { Board, Light } = require("../lib/johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var light = new five.Light({
+board.on("ready", () => {
+  const light = new Light({
     controller: "EVS_NXT",
     pin: "BAS2"
   });
 
-  light.on("change", function() {
-    console.log("Ambient Light Level: ", this.level);
+  light.on("change", (data) => {
+    console.log("Ambient Light Level: ", data.level);
   });
 });

--- a/eg/light-ambient-TSL2561.js
+++ b/eg/light-ambient-TSL2561.js
@@ -1,12 +1,12 @@
-var five = require("../lib/johnny-five.js");
-var board = new five.Board();
+const { Board, Light } = require("../lib/johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var light = new five.Light({
+board.on("ready", () => {
+  const light = new Light({
     controller: "TSL2561",
   });
 
-  light.on("data", function() {
-    console.log("Lux: ", this.lux);
+  light.on("data", (data) => {
+    console.log("Lux: ", data.lux);
   });
 });

--- a/eg/light-reflected-EVS_EV3.js
+++ b/eg/light-reflected-EVS_EV3.js
@@ -1,14 +1,14 @@
-var five = require("../lib/johnny-five.js");
-var board = new five.Board();
+const { Board, Light } = require("../lib/johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var reflect = new five.Light({
+board.on("ready", () => {
+  const reflect = new Light({
     controller: "EVS_EV3",
     pin: "BAS1",
     mode: "reflected"
   });
 
-  reflect.on("change", function() {
-    console.log("Light Reflection Level: ", this.level);
+  reflect.on("change", (data) => {
+    console.log("Light Reflection Level: ", data.level);
   });
 });

--- a/eg/light-reflected-EVS_NXT.js
+++ b/eg/light-reflected-EVS_NXT.js
@@ -1,14 +1,14 @@
-var five = require("../lib/johnny-five.js");
-var board = new five.Board();
+const { Board, Light } = require("../lib/johnny-five");
+const board = new Board();
 
-board.on("ready", function() {
-  var reflect = new five.Light({
+board.on("ready", () => {
+  const reflect = new Light({
     controller: "EVS_NXT",
     pin: "BBS1",
     mode: "reflected"
   });
 
-  reflect.on("change", function() {
-    console.log("Light Reflection Level: ", this.level);
+  reflect.on("change", (data) => {
+    console.log("Light Reflection Level: ", data.level);
   });
 });


### PR DESCRIPTION
This updates the `light`  examples to es6. I used eslint to do most of the work and manually removed binds and a few other things.

Works #1596