### PR TITLE
Update light class to es6

### DIFF
--- a/lib/light.js
+++ b/lib/light.js
@@ -1,32 +1,29 @@
-var Board = require("./board");
-var EVS = require("./evshield");
-var within = require("./mixins/within");
-var Fn = require("./fn");
-var Emitter = require("events").EventEmitter;
-var util = require("util");
-var priv = new Map();
-// var int16 = Fn.int16;
-var uint16 = Fn.uint16;
-var toFixed = Fn.toFixed;
+const Board = require("./board");
+const EVS = require("./evshield");
+const within = require("./mixins/within");
+const { uint16, toFixed, scale } = require("./fn");
+const Emitter = require("events");
+const util = require("util");
+const priv = new Map();
 
-var Controllers = {
+const Controllers = {
   DEFAULT: {
     initialize: {
-      value: function(opts, dataHandler) {
+      value(opts, dataHandler) {
         this.io.pinMode(this.pin, this.io.MODES.ANALOG);
         this.io.analogRead(this.pin, dataHandler);
       },
     },
     toIntensityLevel: {
-      value: function(raw) {
-        return toFixed(Fn.scale(raw, 0, 1023, 0, 100) / 100, 2);
+      value(raw) {
+        return toFixed(scale(raw, 0, 1023, 0, 100) / 100, 2);
       }
     }
   },
   EVS_EV3: {
     initialize: {
-      value: function(opts, dataHandler) {
-        var state = priv.get(this);
+      value(opts, dataHandler) {
+        const state = priv.get(this);
 
         if (opts.mode) {
           opts.mode = opts.mode.toUpperCase();
@@ -40,22 +37,22 @@ var Controllers = {
         }));
         state.ev3.setup(state.shield, EVS.Type_EV3);
         state.ev3.write(state.shield, 0x81 + state.shield.offset, state.mode);
-        state.ev3.read(state.shield, EVS.Light, EVS.Light_Bytes, function(data) {
-          var value = data[0] | (data[1] << 8);
+        state.ev3.read(state.shield, EVS.Light, EVS.Light_Bytes, (data) => {
+          const value = data[0] | (data[1] << 8);
           dataHandler(value);
         });
       }
     },
     toIntensityLevel: {
-      value: function(raw) {
+      value(raw) {
         return toFixed(raw / 100, 2);
       }
     }
   },
   EVS_NXT: {
     initialize: {
-      value: function(opts, dataHandler) {
-        var state = priv.get(this);
+      value(opts, dataHandler) {
+        const state = priv.get(this);
 
         if (opts.mode) {
           opts.mode = opts.mode.toUpperCase();
@@ -68,15 +65,15 @@ var Controllers = {
           io: this.io
         }));
         state.ev3.setup(state.shield, state.mode);
-        state.ev3.read(state.shield, state.shield.analog, EVS.Analog_Bytes, function(data) {
-          var value = data[0] | (data[1] << 8);
+        state.ev3.read(state.shield, state.shield.analog, EVS.Analog_Bytes, (data) => {
+          const value = data[0] | (data[1] << 8);
           dataHandler(value);
         });
       }
     },
     toIntensityLevel: {
-      value: function(raw) {
-        return toFixed(Fn.scale(raw, 0, 1023, 100, 0) / 100, 2);
+      value(raw) {
+        return toFixed(scale(raw, 0, 1023, 100, 0) / 100, 2);
       }
     }
   },
@@ -94,12 +91,9 @@ var Controllers = {
     },
 
     initialize: {
-      value: function(opts, dataHandler) {
-        var address = opts.address || 0x39;
-        var command = function(byte) {
-          // byte | 0b10000000;
-          return byte | 0x80;
-        };
+      value(opts, dataHandler) {
+        const address = opts.address || 0x39;
+        const command = byte => byte | 0b10000000;
 
         opts.address = address;
 
@@ -123,35 +117,35 @@ var Controllers = {
 
         // Page 24
         // Integration time scaling factors
-        var LUX_SCALE = 14; // scale by (2 ** 14)
-        var RATIO_SCALE = 9; // scale ratio by (2 ** 9)
+        const LUX_SCALE = 14; // scale by (2 ** 14)
+        const RATIO_SCALE = 9; // scale ratio by (2 ** 9)
 
         // Page 24
         // T, FN, and CL Package coefficients
-        var K1T = 0x0040; // 0.125 * (2 ** RATIO_SCALE)
-        var B1T = 0x01F2; // 0.0304 * (2 ** LUX_SCALE)
-        var M1T = 0x01BE; // 0.0272 * (2 ** LUX_SCALE)
-        var K2T = 0x0080; // 0.250 * (2 ** RATIO_SCALE)
-        var B2T = 0x0214; // 0.0325 * (2 ** LUX_SCALE)
-        var M2T = 0x02D1; // 0.0440 * (2 ** LUX_SCALE)
-        var K3T = 0x00C0; // 0.375 * (2 ** RATIO_SCALE)
-        var B3T = 0x023F; // 0.0351 * (2 ** LUX_SCALE)
-        var M3T = 0x037B; // 0.0544 * (2 ** LUX_SCALE)
-        var K4T = 0x0100; // 0.50 * (2 ** RATIO_SCALE)
-        var B4T = 0x0270; // 0.0381 * (2 ** LUX_SCALE)
-        var M4T = 0x03FE; // 0.0624 * (2 ** LUX_SCALE)
-        var K5T = 0x0138; // 0.61 * (2 ** RATIO_SCALE)
-        var B5T = 0x016F; // 0.0224 * (2 ** LUX_SCALE)
-        var M5T = 0x01FC; // 0.0310 * (2 ** LUX_SCALE)
-        var K6T = 0x019A; // 0.80 * (2 ** RATIO_SCALE)
-        var B6T = 0x00D2; // 0.0128 * (2 ** LUX_SCALE)
-        var M6T = 0x00FB; // 0.0153 * (2 ** LUX_SCALE)
-        var K7T = 0x029A; // 1.3 * (2 ** RATIO_SCALE)
-        var B7T = 0x0018; // 0.00146 * (2 ** LUX_SCALE)
-        var M7T = 0x0012; // 0.00112 * (2 ** LUX_SCALE)
-        var K8T = 0x029A; // 1.3 * (2 ** RATIO_SCALE)
-        var B8T = 0x0000; // 0.000 * (2 ** LUX_SCALE)
-        var M8T = 0x0000; // 0.000 * (2 ** LUX_SCALE)
+        const K1T = 0x0040; // 0.125 * (2 ** RATIO_SCALE)
+        const B1T = 0x01F2; // 0.0304 * (2 ** LUX_SCALE)
+        const M1T = 0x01BE; // 0.0272 * (2 ** LUX_SCALE)
+        const K2T = 0x0080; // 0.250 * (2 ** RATIO_SCALE)
+        const B2T = 0x0214; // 0.0325 * (2 ** LUX_SCALE)
+        const M2T = 0x02D1; // 0.0440 * (2 ** LUX_SCALE)
+        const K3T = 0x00C0; // 0.375 * (2 ** RATIO_SCALE)
+        const B3T = 0x023F; // 0.0351 * (2 ** LUX_SCALE)
+        const M3T = 0x037B; // 0.0544 * (2 ** LUX_SCALE)
+        const K4T = 0x0100; // 0.50 * (2 ** RATIO_SCALE)
+        const B4T = 0x0270; // 0.0381 * (2 ** LUX_SCALE)
+        const M4T = 0x03FE; // 0.0624 * (2 ** LUX_SCALE)
+        const K5T = 0x0138; // 0.61 * (2 ** RATIO_SCALE)
+        const B5T = 0x016F; // 0.0224 * (2 ** LUX_SCALE)
+        const M5T = 0x01FC; // 0.0310 * (2 ** LUX_SCALE)
+        const K6T = 0x019A; // 0.80 * (2 ** RATIO_SCALE)
+        const B6T = 0x00D2; // 0.0128 * (2 ** LUX_SCALE)
+        const M6T = 0x00FB; // 0.0153 * (2 ** LUX_SCALE)
+        const K7T = 0x029A; // 1.3 * (2 ** RATIO_SCALE)
+        const B7T = 0x0018; // 0.00146 * (2 ** LUX_SCALE)
+        const M7T = 0x0012; // 0.00112 * (2 ** LUX_SCALE)
+        const K8T = 0x029A; // 1.3 * (2 ** RATIO_SCALE)
+        const B8T = 0x0000; // 0.000 * (2 ** LUX_SCALE)
+        const M8T = 0x0000; // 0.000 * (2 ** LUX_SCALE)
 
         // Auto-gain thresholds
         // Max value at Ti 13ms = 5047
@@ -189,14 +183,14 @@ var Controllers = {
         // ];
 
 
-        var GAIN_1X = 0x00;
-        var GAIN_16X = 0x10;
+        const GAIN_1X = 0x00;
+        const GAIN_16X = 0x10;
 
         // var TI_13MS = 0x00;
         // var TI_101MS = 0x01;
         // var TI_402MS = 0x02;
 
-        var TintMs = [
+        const TintMs = [
           // 0, TI_13MS
           13,
           // 1, TI_101MS
@@ -205,7 +199,7 @@ var Controllers = {
           402,
         ];
 
-        var TintDelayMs = [
+        const TintDelayMs = [
           // 0, TI_13MS
           15,
           // 1, TI_101MS
@@ -220,7 +214,7 @@ var Controllers = {
         // var CH_SCALE_0 = 0x7517;
         // var CH_SCALE_1 = 0x0FE7;
 
-        var chScales = [
+        const chScales = [
           // 0, TI_13MS
           0x07517,
           // 1, TI_101MS
@@ -230,10 +224,10 @@ var Controllers = {
         ];
 
         // Gain and Tint defaults;
-        var gain = GAIN_16X;
-        var TintIndex = 0;
-        var Tint = TintMs[TintIndex];
-        var lux = 0;
+        let gain = GAIN_16X;
+        let TintIndex = 0;
+        let Tint = TintMs[TintIndex];
+        let lux = 0;
 
         // if (typeof opts.gain !== "undefined") {
         //   isAutoGain = false;
@@ -249,10 +243,10 @@ var Controllers = {
         // TODO: reduce duplication here
         Object.defineProperties(this, {
           gain: {
-            get: function() {
+            get() {
               return gain;
             },
-            set: function(value) {
+            set(value) {
               if (value !== GAIN_1X && value !== GAIN_16X) {
                 throw new RangeError("Invalid gain. Expected one of: 0, 16");
               }
@@ -262,10 +256,10 @@ var Controllers = {
             }
           },
           integration: {
-            get: function() {
+            get() {
               return Tint;
             },
-            set: function(value) {
+            set(value) {
               TintIndex = TintMs.indexOf(value);
 
               if (TintIndex === -1) {
@@ -278,7 +272,7 @@ var Controllers = {
             }
           },
           lux: {
-            get: function() {
+            get() {
               return lux;
             }
           }
@@ -299,21 +293,21 @@ var Controllers = {
         //   infrared: null,
         // };
 
-        var read = function() {
-          setTimeout(function() {
+        const read = () => {
+          setTimeout(() => {
             // Page 19
             // Read ADC Channels Using Read Word Protocol − RECOMMENDED
-            this.io.i2cReadOnce(address, command(this.REGISTER.READ), 4, function(data) {
+            this.io.i2cReadOnce(address, command(this.REGISTER.READ), 4, (data) => {
               // Page 23 - 28
               // Simplified Lux Calculation
-              var ch0 = uint16(data[1], data[0]);
-              var ch1 = uint16(data[3], data[2]);
-              var b = 0;
-              var m = 0;
+              let ch0 = uint16(data[1], data[0]);
+              let ch1 = uint16(data[3], data[2]);
+              let b = 0;
+              let m = 0;
 
               // Page 26
               // CalculateLux(...)
-              var chScale = chScales[TintIndex];
+              let chScale = chScales[TintIndex];
 
 
               if (!gain) {
@@ -325,7 +319,7 @@ var Controllers = {
               ch0 = (ch0 * chScale) >> 10;
               ch1 = (ch1 * chScale) >> 10;
 
-              var ratio1 = 0;
+              let ratio1 = 0;
 
               if (ch0) {
                 ratio1 = (ch1 << (RATIO_SCALE + 1)) / ch0;
@@ -333,7 +327,7 @@ var Controllers = {
 
               ratio1 = Math.round(ratio1);
 
-              var ratio = (ratio1 + 1) >> 1;
+              const ratio = (ratio1 + 1) >> 1;
 
               if (ratio >= 0 && ratio <= K1T) {
                 b = B1T;
@@ -362,7 +356,7 @@ var Controllers = {
               }
               // I followed the datasheet and it had no else clause here.
 
-              var temp = (ch0 * b) - (ch1 * m);
+              let temp = (ch0 * b) - (ch1 * m);
 
               if (temp < 0) {
                 temp = 0;
@@ -377,20 +371,20 @@ var Controllers = {
               dataHandler(lux);
               read();
             });
-          }.bind(this), TintDelayMs[TintIndex]);
-        }.bind(this);
+          }, TintDelayMs[TintIndex]);
+        };
 
         read();
       }
     },
     toLux: {
-      value: function(raw) {
+      value(raw) {
         return raw;
       },
     },
     toIntensityLevel: {
-      value: function(raw) {
-        return toFixed(Fn.scale(raw, 0, 17000, 0, 100) / 100, 2);
+      value(raw) {
+        return toFixed(scale(raw, 0, 17000, 0, 100) / 100, 2);
       },
     },
   },
@@ -401,36 +395,36 @@ var Controllers = {
       value: [0x23, 0x5C]
     },
     initialize: {
-      value: function(opts, dataHandler) {
-        var address = opts.address || 0x23;
-        var mode = opts.mode || 0x10;
+      value(opts, dataHandler) {
+        const address = opts.address || 0x23;
+        const mode = opts.mode || 0x10;
         opts.address = address;
         this.io.i2cConfig(opts);
         this.io.i2cWrite(address, mode);
-        var read = function() {
-          setTimeout(function() {
-            this.io.i2cReadOnce(address, 2, function(data) {
-              var raw = data[0];
+        const read = () => {
+          setTimeout(() => {
+            this.io.i2cReadOnce(address, 2, (data) => {
+              let raw = data[0];
               raw <<= 8;
               raw |= data[1];
               dataHandler(raw);
               read();
             });
-          }.bind(this), 120);
-        }.bind(this);
+          }, 120);
+        };
         read();
       },
     },
     toLux: {
-      value: function(raw) {
+      value(raw) {
         // Page 2
         // H-Resolution Mode Resolution rHR － 1 － lx
         return Math.round(raw / 1.2);
       },
     },
     toIntensityLevel: {
-      value: function(raw) {
-        return toFixed(Fn.scale(raw / 1.2, 0, 65535, 0, 100) / 100, 2);
+      value(raw) {
+        return toFixed(scale(raw / 1.2, 0, 65535, 0, 100) / 100, 2);
       },
     },
   },
@@ -451,11 +445,10 @@ function Light(opts) {
     return new Light(opts);
   }
 
-  var controller = null;
-  var state = {};
-  var raw = 0;
-  var last = 0;
-  var freq = opts.freq || 25;
+  let controller = null;
+  let raw = 0;
+  let last = 0;
+  const freq = opts.freq || 25;
 
   Board.Component.call(
     this, opts = Board.Options(opts)
@@ -483,40 +476,40 @@ function Light(opts) {
 
   Object.defineProperties(this, {
     value: {
-      get: function() {
+      get() {
         return raw;
       },
     },
     level: {
-      get: function() {
+      get() {
         return this.toIntensityLevel(raw);
       },
     },
   });
 
-  priv.set(this, state);
+  priv.set(this, {});
 
   /* istanbul ignore else */
   if (typeof this.initialize === "function") {
-    this.initialize(opts, function(data) {
+    this.initialize(opts, (data) => {
       raw = data;
     });
   }
 
   if (typeof this.lux === "undefined") {
     Object.defineProperty(this, "lux", {
-      get: function() {
+      get() {
         return this.toLux(raw);
       },
     });
   }
 
-  var data = {
+  const data = {
     level: 0,
     lux: 0,
   };
 
-  setInterval(function() {
+  setInterval(() => {
     data.level = this.level;
     data.lux = this.lux;
 
@@ -526,7 +519,7 @@ function Light(opts) {
       last = raw;
       this.emit("change", data);
     }
-  }.bind(this), freq);
+  }, freq);
 }
 
 util.inherits(Light, Emitter);
@@ -535,7 +528,7 @@ Object.assign(Light.prototype, within);
 
 
 /* istanbul ignore else */
-if (!!process.env.IS_TEST_MODE) {
+if (process.env.IS_TEST_MODE) {
   Light.Controllers = Controllers;
   Light.purge = function() {
     priv.clear();

--- a/test/light.js
+++ b/test/light.js
@@ -1,10 +1,10 @@
 require("./common/bootstrap");
 
-var proto = [{
+const proto = [{
   name: "within",
 }];
 
-var instance = [{
+const instance = [{
   name: "value",
 }, {
   name: "level",
@@ -13,7 +13,7 @@ var instance = [{
 }];
 
 exports["Light"] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.board = newBoard();
     this.clock = this.sandbox.useFakeTimers();
@@ -22,14 +22,14 @@ exports["Light"] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     Board.purge();
     Light.purge();
     this.sandbox.restore();
     done();
   },
 
-  shape: function(test) {
+  shape(test) {
     test.expect(proto.length + instance.length);
 
     this.light = new Light({
@@ -49,13 +49,13 @@ exports["Light"] = {
     test.done();
   },
 
-  instanceof: function(test) {
+  instanceof(test) {
     test.expect(1);
     test.equal(Light({ board: this.board }) instanceof Light, true);
     test.done();
   },
 
-  component: function(test) {
+  component(test) {
     test.expect(1);
 
     new Light({ board: this.board });
@@ -64,7 +64,7 @@ exports["Light"] = {
     test.done();
   },
 
-  emitter: function(test) {
+  emitter(test) {
     test.expect(1);
 
     this.light = new Light({
@@ -77,13 +77,13 @@ exports["Light"] = {
     test.done();
   },
 
-  customIntensityLevel: function(test) {
+  customIntensityLevel(test) {
     test.expect(2);
 
     this.light = new Light({
       board: this.board,
       controller: {},
-      toIntensityLevel: function(x) {
+      toIntensityLevel(x) {
         test.ok(true);
         return x * x;
       },
@@ -93,7 +93,7 @@ exports["Light"] = {
     test.done();
   },
 
-  fallbackIntensityLevel: function(test) {
+  fallbackIntensityLevel(test) {
     test.expect(1);
 
     this.light = new Light({
@@ -107,7 +107,7 @@ exports["Light"] = {
 };
 
 exports["Light: ALSPT19"] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.board = newBoard();
     this.clock = this.sandbox.useFakeTimers();
@@ -122,14 +122,14 @@ exports["Light: ALSPT19"] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     Board.purge();
     Light.purge();
     this.sandbox.restore();
     done();
   },
 
-  shape: function(test) {
+  shape(test) {
     test.expect(proto.length + instance.length);
 
     proto.forEach(function(method) {
@@ -143,7 +143,7 @@ exports["Light: ALSPT19"] = {
     test.done();
   },
 
-  emitter: function(test) {
+  emitter(test) {
     test.expect(1);
     test.ok(this.light instanceof Emitter);
     test.done();
@@ -151,7 +151,7 @@ exports["Light: ALSPT19"] = {
 };
 
 exports["Light: BH1750"] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.board = newBoard();
     this.clock = this.sandbox.useFakeTimers();
@@ -168,14 +168,14 @@ exports["Light: BH1750"] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     Board.purge();
     Light.purge();
     this.sandbox.restore();
     done();
   },
 
-  fwdOptionsToi2cConfig: function(test) {
+  fwdOptionsToi2cConfig(test) {
     test.expect(3);
 
     this.i2cConfig.reset();
@@ -187,7 +187,7 @@ exports["Light: BH1750"] = {
       board: this.board
     });
 
-    var forwarded = this.i2cConfig.lastCall.args[0];
+    const forwarded = this.i2cConfig.lastCall.args[0];
 
     test.equal(this.i2cConfig.callCount, 1);
     test.equal(forwarded.address, 0xff);
@@ -196,7 +196,7 @@ exports["Light: BH1750"] = {
     test.done();
   },
 
-  initialization: function(test) {
+  initialization(test) {
     test.expect(4);
     test.equal(this.i2cConfig.callCount, 1);
     test.equal(this.i2cWrite.callCount, 1);
@@ -205,13 +205,13 @@ exports["Light: BH1750"] = {
     test.done();
   },
 
-  data: function(test) {
+  data(test) {
     test.expect(3);
 
     this.clock.tick(120);
 
-    var read = this.i2cReadOnce.lastCall.args[2];
-    var spy = this.sandbox.spy();
+    const read = this.i2cReadOnce.lastCall.args[2];
+    const spy = this.sandbox.spy();
 
     this.light.on("data", spy);
 
@@ -226,13 +226,13 @@ exports["Light: BH1750"] = {
     test.done();
   },
 
-  change: function(test) {
+  change(test) {
     test.expect(6);
 
     this.clock.tick(120);
 
-    var read = this.i2cReadOnce.lastCall.args[2];
-    var spy = this.sandbox.spy();
+    const read = this.i2cReadOnce.lastCall.args[2];
+    const spy = this.sandbox.spy();
 
     this.light.on("change", spy);
 
@@ -255,7 +255,7 @@ exports["Light: BH1750"] = {
 };
 
 exports["Light: TSL2561"] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.board = newBoard();
     this.clock = this.sandbox.useFakeTimers();
@@ -273,14 +273,14 @@ exports["Light: TSL2561"] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     Board.purge();
     Light.purge();
     this.sandbox.restore();
     done();
   },
 
-  fwdOptionsToi2cConfig: function(test) {
+  fwdOptionsToi2cConfig(test) {
     test.expect(3);
 
     this.i2cConfig.reset();
@@ -292,7 +292,7 @@ exports["Light: TSL2561"] = {
       board: this.board
     });
 
-    var forwarded = this.i2cConfig.lastCall.args[0];
+    const forwarded = this.i2cConfig.lastCall.args[0];
 
     test.equal(this.i2cConfig.callCount, 1);
     test.equal(forwarded.address, 0xff);
@@ -301,7 +301,7 @@ exports["Light: TSL2561"] = {
     test.done();
   },
 
-  initialization: function(test) {
+  initialization(test) {
     test.expect(4);
     test.equal(this.i2cConfig.callCount, 1);
     test.equal(this.i2cWriteReg.callCount, 3);
@@ -313,7 +313,7 @@ exports["Light: TSL2561"] = {
 };
 
 exports["Light: EVS_EV3, Ambient (Default)"] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.board = newBoard();
     this.clock = this.sandbox.useFakeTimers();
@@ -324,7 +324,7 @@ exports["Light: EVS_EV3, Ambient (Default)"] = {
 
     this.i2cConfig = this.sandbox.spy(MockFirmata.prototype, "i2cConfig");
     this.i2cWrite = this.sandbox.spy(MockFirmata.prototype, "i2cWrite");
-    this.i2cRead = this.sandbox.stub(MockFirmata.prototype, "i2cRead", function(address, register, numBytes, callback) {
+    this.i2cRead = this.sandbox.stub(MockFirmata.prototype, "i2cRead", (address, register, numBytes, callback) => {
       callback([15, 0]);
     });
 
@@ -338,14 +338,14 @@ exports["Light: EVS_EV3, Ambient (Default)"] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     Board.purge();
     Light.purge();
     this.sandbox.restore();
     done();
   },
 
-  shape: function(test) {
+  shape(test) {
     test.expect(proto.length + instance.length);
 
     proto.forEach(function(method) {
@@ -359,10 +359,10 @@ exports["Light: EVS_EV3, Ambient (Default)"] = {
     test.done();
   },
 
-  initialization: function(test) {
+  initialization(test) {
     test.expect(2);
 
-    var shield = {
+    const shield = {
       address: 26,
       analog: 112,
       bank: "a",
@@ -379,8 +379,8 @@ exports["Light: EVS_EV3, Ambient (Default)"] = {
     test.done();
   },
 
-  data: function(test) {
-    var spy = this.sandbox.spy();
+  data(test) {
+    const spy = this.sandbox.spy();
     test.expect(1);
 
     this.light.on("data", spy);
@@ -389,10 +389,10 @@ exports["Light: EVS_EV3, Ambient (Default)"] = {
     test.done();
   },
 
-  change: function(test) {
+  change(test) {
     test.expect(1);
 
-    var spy = this.sandbox.spy();
+    const spy = this.sandbox.spy();
 
     this.light.on("change", spy);
 
@@ -402,8 +402,8 @@ exports["Light: EVS_EV3, Ambient (Default)"] = {
     test.done();
   },
 
-  within: function(test) {
-    var spy = this.sandbox.spy();
+  within(test) {
+    const spy = this.sandbox.spy();
     test.expect(2);
 
     this.clock.tick(250);
@@ -420,7 +420,7 @@ exports["Light: EVS_EV3, Ambient (Default)"] = {
 };
 
 exports["Light: EVS_EV3, Reflected"] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.board = newBoard();
     this.clock = this.sandbox.useFakeTimers();
@@ -431,7 +431,7 @@ exports["Light: EVS_EV3, Reflected"] = {
 
     this.i2cConfig = this.sandbox.spy(MockFirmata.prototype, "i2cConfig");
     this.i2cWrite = this.sandbox.spy(MockFirmata.prototype, "i2cWrite");
-    this.i2cRead = this.sandbox.stub(MockFirmata.prototype, "i2cRead", function(address, register, numBytes, callback) {
+    this.i2cRead = this.sandbox.stub(MockFirmata.prototype, "i2cRead", (address, register, numBytes, callback) => {
       callback([15, 0]);
     });
 
@@ -446,14 +446,14 @@ exports["Light: EVS_EV3, Reflected"] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     Board.purge();
     Light.purge();
     this.sandbox.restore();
     done();
   },
 
-  shape: function(test) {
+  shape(test) {
     test.expect(proto.length + instance.length);
 
     proto.forEach(function(method) {
@@ -467,10 +467,10 @@ exports["Light: EVS_EV3, Reflected"] = {
     test.done();
   },
 
-  initialization: function(test) {
+  initialization(test) {
     test.expect(2);
 
-    var shield = {
+    const shield = {
       address: 26,
       analog: 112,
       bank: "a",
@@ -487,8 +487,8 @@ exports["Light: EVS_EV3, Reflected"] = {
     test.done();
   },
 
-  data: function(test) {
-    var spy = this.sandbox.spy();
+  data(test) {
+    const spy = this.sandbox.spy();
     test.expect(1);
 
     this.light.on("data", spy);
@@ -497,10 +497,10 @@ exports["Light: EVS_EV3, Reflected"] = {
     test.done();
   },
 
-  change: function(test) {
+  change(test) {
     test.expect(1);
 
-    var spy = this.sandbox.spy();
+    const spy = this.sandbox.spy();
 
     this.light.on("change", spy);
 
@@ -510,8 +510,8 @@ exports["Light: EVS_EV3, Reflected"] = {
     test.done();
   },
 
-  within: function(test) {
-    var spy = this.sandbox.spy();
+  within(test) {
+    const spy = this.sandbox.spy();
     test.expect(2);
 
     this.clock.tick(250);
@@ -528,7 +528,7 @@ exports["Light: EVS_EV3, Reflected"] = {
 };
 
 exports["Light: EVS_NXT, Ambient (Default)"] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.board = newBoard();
     this.clock = this.sandbox.useFakeTimers();
@@ -539,7 +539,7 @@ exports["Light: EVS_NXT, Ambient (Default)"] = {
 
     this.i2cConfig = this.sandbox.spy(MockFirmata.prototype, "i2cConfig");
     this.i2cWrite = this.sandbox.spy(MockFirmata.prototype, "i2cWrite");
-    this.i2cRead = this.sandbox.stub(MockFirmata.prototype, "i2cRead", function(address, register, numBytes, callback) {
+    this.i2cRead = this.sandbox.stub(MockFirmata.prototype, "i2cRead", (address, register, numBytes, callback) => {
       callback([100, 3]);
     });
 
@@ -553,14 +553,14 @@ exports["Light: EVS_NXT, Ambient (Default)"] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     Board.purge();
     Light.purge();
     this.sandbox.restore();
     done();
   },
 
-  shape: function(test) {
+  shape(test) {
     test.expect(proto.length + instance.length);
 
     proto.forEach(function(method) {
@@ -574,10 +574,10 @@ exports["Light: EVS_NXT, Ambient (Default)"] = {
     test.done();
   },
 
-  initialization: function(test) {
+  initialization(test) {
     test.expect(1);
 
-    var shield = {
+    const shield = {
       address: 26,
       analog: 112,
       bank: "a",
@@ -593,8 +593,8 @@ exports["Light: EVS_NXT, Ambient (Default)"] = {
     test.done();
   },
 
-  data: function(test) {
-    var spy = this.sandbox.spy();
+  data(test) {
+    const spy = this.sandbox.spy();
     test.expect(1);
 
     this.light.on("data", spy);
@@ -603,10 +603,10 @@ exports["Light: EVS_NXT, Ambient (Default)"] = {
     test.done();
   },
 
-  change: function(test) {
+  change(test) {
     test.expect(1);
 
-    var spy = this.sandbox.spy();
+    const spy = this.sandbox.spy();
 
     this.light.on("change", spy);
 
@@ -616,8 +616,8 @@ exports["Light: EVS_NXT, Ambient (Default)"] = {
     test.done();
   },
 
-  within: function(test) {
-    var spy = this.sandbox.spy();
+  within(test) {
+    const spy = this.sandbox.spy();
     test.expect(2);
 
     this.clock.tick(250);
@@ -634,7 +634,7 @@ exports["Light: EVS_NXT, Ambient (Default)"] = {
 };
 
 exports["Light: EVS_NXT, Reflected"] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.board = newBoard();
     this.clock = this.sandbox.useFakeTimers();
@@ -645,7 +645,7 @@ exports["Light: EVS_NXT, Reflected"] = {
 
     this.i2cConfig = this.sandbox.spy(MockFirmata.prototype, "i2cConfig");
     this.i2cWrite = this.sandbox.spy(MockFirmata.prototype, "i2cWrite");
-    this.i2cRead = this.sandbox.stub(MockFirmata.prototype, "i2cRead", function(address, register, numBytes, callback) {
+    this.i2cRead = this.sandbox.stub(MockFirmata.prototype, "i2cRead", (address, register, numBytes, callback) => {
       callback([100, 3]);
     });
 
@@ -660,14 +660,14 @@ exports["Light: EVS_NXT, Reflected"] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     Board.purge();
     Light.purge();
     this.sandbox.restore();
     done();
   },
 
-  shape: function(test) {
+  shape(test) {
     test.expect(proto.length + instance.length);
 
     proto.forEach(function(method) {
@@ -681,10 +681,10 @@ exports["Light: EVS_NXT, Reflected"] = {
     test.done();
   },
 
-  initialization: function(test) {
+  initialization(test) {
     test.expect(1);
 
-    var shield = {
+    const shield = {
       address: 26,
       analog: 112,
       bank: "a",
@@ -700,8 +700,8 @@ exports["Light: EVS_NXT, Reflected"] = {
     test.done();
   },
 
-  data: function(test) {
-    var spy = this.sandbox.spy();
+  data(test) {
+    const spy = this.sandbox.spy();
     test.expect(1);
 
     this.light.on("data", spy);
@@ -710,10 +710,10 @@ exports["Light: EVS_NXT, Reflected"] = {
     test.done();
   },
 
-  change: function(test) {
+  change(test) {
     test.expect(1);
 
-    var spy = this.sandbox.spy();
+    const spy = this.sandbox.spy();
 
     this.light.on("change", spy);
 
@@ -723,8 +723,8 @@ exports["Light: EVS_NXT, Reflected"] = {
     test.done();
   },
 
-  within: function(test) {
-    var spy = this.sandbox.spy();
+  within(test) {
+    const spy = this.sandbox.spy();
     test.expect(2);
 
     this.clock.tick(250);


### PR DESCRIPTION
This updates the `light` class to es6. I used eslint to do most of the work and manually removed binds and a few other things.

This doesn’t move to actually using ES6 Classes. Should we do that?

(moved from #1601)