### PR TITLE
Add support for PCA9685_Hybrid motors

### DIFF
--- a/lib/motor.js
+++ b/lib/motor.js
@@ -119,6 +119,36 @@ var Controllers = {
       }
     }
   },
+  PCA9685_Hybrid: {
+    setPWM: {
+      writable: true,
+      value: function(pin, speed) {
+        var state = priv.get(this);
+        state.expander.analogWrite(pin, speed);
+      }
+    },
+    initialize: {
+      value: function(opts) {
+
+        var state = priv.get(this);
+
+        this.address = opts.address || 0x40;
+        this.pwmRange = opts.pwmRange || [0, 4080];
+        this.frequency = opts.frequency || 50;
+
+        state.expander = Expander.get({
+          address: this.address,
+          controller: "PCA9685",
+          bus: this.bus,
+          pwmRange: this.pwmRange,
+          frequency: this.frequency,
+        });
+
+        this.pins.pwm = state.expander.normalize(this.pins.pwm);
+
+      }
+    }
+  },
   EVS_EV3: {
     initialize: {
       value: function(opts) {
@@ -1151,9 +1181,25 @@ Motor.SHIELD_CONFIGS = {
       }
     }
   },
-
+  PICAR_V: {
+    A: {
+      controller: "PCA9685_Hybrid",
+      invertPWM: true,
+      pins: {
+        pwm: 4,
+        dir: "GPIO17"
+      }
+    },
+    B: {
+      controller: "PCA9685_Hybrid",
+      invertPWM: true,
+      pins: {
+        pwm: 5,
+        dir: "GPIO27"
+      }
+    }
+  }
 };
-
 
 /**
  * Motors()


### PR DESCRIPTION
It is entirely reasonable to want to control a motor using a PCA9685 for speed and regular GPIO pins for direction. This PR allows for that.

Addresses #1624 