### PR TITLE
chore: Upgrade SerialPort to v8

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -39,27 +39,24 @@ var Serial = {
     // Request a list of available ports, from
     // the result set, filter for valid paths
     // via known path pattern match.
-    serialport.list(function(err, result) {
-
-      // serialport.list() will never result in an error.
-      // On failure, an empty array is returned. (#768)
+    serialport.list().then(result => {
       var ports = result.filter(function(val) {
         var available = true;
 
         // Match only ports that Arduino cares about
         // ttyUSB#, cu.usbmodem#, COM#
-        if (!rport.test(val.comName)) {
+        if (!rport.test(val.path)) {
           available = false;
         }
 
         // Don't allow already used/encountered usb device paths
-        if (Serial.used.includes(val.comName)) {
+        if (Serial.used.includes(val.path)) {
           available = false;
         }
 
         return available;
       }).map(function(val) {
-        return val.comName;
+        return val.path;
       });
 
       // If no ports are detected...
@@ -101,7 +98,7 @@ var Serial = {
       // from the list of detected ports
 
       callback.call(this, ports[0]);
-    }.bind(this));
+    });
   },
 
   connect: function(portOrPath, callback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,23 +134,6 @@
       "optional": true,
       "requires": {
         "debug": "^4.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "optional": true
-        }
       }
     },
     "@serialport/binding-mock": {
@@ -161,23 +144,6 @@
       "requires": {
         "@serialport/binding-abstract": "^2.0.5",
         "debug": "^4.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "optional": true
-        }
       }
     },
     "@serialport/bindings": {
@@ -192,23 +158,6 @@
         "debug": "^4.1.1",
         "nan": "^2.13.2",
         "prebuild-install": "^5.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "optional": true
-        }
       }
     },
     "@serialport/parser-byte-length": {
@@ -258,23 +207,6 @@
       "requires": {
         "@serialport/binding-mock": "^2.0.5",
         "debug": "^4.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "optional": true
-        }
       }
     },
     "JSV": {
@@ -503,43 +435,38 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
       "optional": true,
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "^3.0.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "optional": true
-        },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "optional": true
+        },
         "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         }
       }
@@ -591,28 +518,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/browser-serialport/-/browser-serialport-2.1.0.tgz",
       "integrity": "sha1-+4QHfoS5u7uEk1quH8rJzmEF3H8=",
-      "optional": true
-    },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "optional": true,
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "optional": true
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "optional": true
     },
     "buffer-from": {
@@ -697,9 +602,9 @@
       "dev": true
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
       "optional": true
     },
     "clean-yaml-object": {
@@ -1077,7 +982,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       },
@@ -1085,8 +989,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -1097,12 +1000,12 @@
       "dev": true
     },
     "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
       "optional": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "^2.0.0"
       }
     },
     "deep-equal": {
@@ -1259,9 +1162,9 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "optional": true,
       "requires": {
         "once": "^1.4.0"
@@ -1449,6 +1352,26 @@
       "requires": {
         "firmata-io": "^2.0.0",
         "serialport": "^7.1.3"
+      },
+      "dependencies": {
+        "serialport": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/serialport/-/serialport-7.1.5.tgz",
+          "integrity": "sha512-NplGdqaY+ZL8t3t5egbT+3oqLW4d7WvDT/x1ACxAyWa1fSnx+KTAmlDHeCls39lXwu8voaOr3bPOW4bwM7PdAA==",
+          "optional": true,
+          "requires": {
+            "@serialport/binding-mock": "^2.0.5",
+            "@serialport/bindings": "^2.0.8",
+            "@serialport/parser-byte-length": "^2.0.2",
+            "@serialport/parser-cctalk": "^2.0.2",
+            "@serialport/parser-delimiter": "^2.0.2",
+            "@serialport/parser-readline": "^2.0.2",
+            "@serialport/parser-ready": "^2.0.2",
+            "@serialport/parser-regex": "^2.0.2",
+            "@serialport/stream": "^2.0.5",
+            "debug": "^4.1.1"
+          }
+        }
       }
     },
     "firmata-io": {
@@ -2719,9 +2642,9 @@
       }
     },
     "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+      "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
       "optional": true
     },
     "minimatch": {
@@ -2799,9 +2722,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
     },
     "nanotimer": {
@@ -2840,18 +2763,18 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
-      "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
+      "integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
       "optional": true,
       "requires": {
         "semver": "^5.4.1"
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "optional": true
         }
       }
@@ -3508,7 +3431,8 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "own-or": {
       "version": "1.0.0",
@@ -3670,9 +3594,9 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
-      "integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+      "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
       "optional": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -3684,11 +3608,10 @@
         "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
+        "pump": "^3.0.0",
         "rc": "^1.2.7",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0",
         "which-pm-runs": "^1.0.0"
       }
@@ -3725,9 +3648,9 @@
       "dev": true
     },
     "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "optional": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -3970,37 +3893,104 @@
       "dev": true
     },
     "serialport": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-7.1.5.tgz",
-      "integrity": "sha512-NplGdqaY+ZL8t3t5egbT+3oqLW4d7WvDT/x1ACxAyWa1fSnx+KTAmlDHeCls39lXwu8voaOr3bPOW4bwM7PdAA==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-8.0.5.tgz",
+      "integrity": "sha512-hYWRpn+pRZWxwCZErLkYcja/ELSrB70dl+z9TcKIHKO2SlHDVNJmXAGGw2nfjg3AqmsHZvRRq8fu1SySYzbZUA==",
       "optional": true,
       "requires": {
-        "@serialport/binding-mock": "^2.0.5",
-        "@serialport/bindings": "^2.0.8",
-        "@serialport/parser-byte-length": "^2.0.2",
-        "@serialport/parser-cctalk": "^2.0.2",
-        "@serialport/parser-delimiter": "^2.0.2",
-        "@serialport/parser-readline": "^2.0.2",
-        "@serialport/parser-ready": "^2.0.2",
-        "@serialport/parser-regex": "^2.0.2",
-        "@serialport/stream": "^2.0.5",
+        "@serialport/binding-mock": "^8.0.4",
+        "@serialport/bindings": "^8.0.4",
+        "@serialport/parser-byte-length": "^8.0.4",
+        "@serialport/parser-cctalk": "^8.0.4",
+        "@serialport/parser-delimiter": "^8.0.4",
+        "@serialport/parser-readline": "^8.0.4",
+        "@serialport/parser-ready": "^8.0.4",
+        "@serialport/parser-regex": "^8.0.4",
+        "@serialport/stream": "^8.0.4",
         "debug": "^4.1.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "@serialport/binding-abstract": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-8.0.4.tgz",
+          "integrity": "sha512-1/CWzAk0tIlaf+WkTYD9YogUi6RGurNSV78cHlpkwsJeLY7z3i1rtwapspV5lIziGT/UJPj8pNVcXrv3K2uKZQ==",
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "debug": "^4.1.1"
           }
         },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+        "@serialport/binding-mock": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-8.0.4.tgz",
+          "integrity": "sha512-n6XGkZQaEOZk+wvxKSCNwv9wopS3faD1nf97FJJwJXZdtKk7h2XFtScfrol3bBfHanDMLjwx8oLgs29Jtlxmwg==",
+          "optional": true,
+          "requires": {
+            "@serialport/binding-abstract": "^8.0.4",
+            "debug": "^4.1.1"
+          }
+        },
+        "@serialport/bindings": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-8.0.4.tgz",
+          "integrity": "sha512-VNEJs6swCw9D4X0M08850RFvj5wUt+YiVQrQ9/ms9sYfuh//S/TsEKKQuVkyYtaTkiyZUgknkzBH/8u74w8aKQ==",
+          "optional": true,
+          "requires": {
+            "@serialport/binding-abstract": "^8.0.4",
+            "@serialport/parser-readline": "^8.0.4",
+            "bindings": "^1.5.0",
+            "debug": "^4.1.1",
+            "nan": "^2.14.0",
+            "prebuild-install": "^5.3.0"
+          }
+        },
+        "@serialport/parser-byte-length": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-8.0.4.tgz",
+          "integrity": "sha512-5tQQbJZ5KL0eaP750oF1w0iT+E3lFkpDRz/BzONS2jJsGc+Warb+6FH2aWqj1+smz0mAZWdcxNQgJZLrhFy+sw==",
           "optional": true
+        },
+        "@serialport/parser-cctalk": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-8.0.4.tgz",
+          "integrity": "sha512-7GsVAlVgk9pAMfuhbEy5m5t1pe8WCdR8HzXjroE8jwXCPHrGT7aY/sjZSTF91fx+qzqhojLiTJyIlf1HwnqM+g==",
+          "optional": true
+        },
+        "@serialport/parser-delimiter": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-8.0.4.tgz",
+          "integrity": "sha512-4XkOQD2uj7jj4q4CltAM74Rk3HNwCk8pqrgvfAtouA3Pmt0AdrC/n9OrpRY13ioZwv+Yjc54HWU2z9VOOGn45Q==",
+          "optional": true
+        },
+        "@serialport/parser-readline": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-8.0.4.tgz",
+          "integrity": "sha512-STs0WnGKLBwlXbG3CnTiI+kuWxmHBzwcslrWA2su9G5pPYQJpKGCHs2URLDDhYKmGZtzTftCJXEXABpsTXfNxQ==",
+          "optional": true,
+          "requires": {
+            "@serialport/parser-delimiter": "^8.0.4"
+          }
+        },
+        "@serialport/parser-ready": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-8.0.4.tgz",
+          "integrity": "sha512-HXFmYve6mcFnOyX/efLvo7MpvOtD0uJrYWXFvuk0xw3DYRBvabL1zYvK0rYPrWJu32I0M3AFFsldSELm0Ic3mQ==",
+          "optional": true
+        },
+        "@serialport/parser-regex": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-8.0.4.tgz",
+          "integrity": "sha512-uruaOaxBN4E90oqW/Tfb594uP9qPEgL79XXwXUQGbT554EK4k1VVa9TV1JO16qE8EB6Km6XxdEPEVxAx7HKmpg==",
+          "optional": true
+        },
+        "@serialport/stream": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-8.0.4.tgz",
+          "integrity": "sha512-Ux6qhFRPGiW/2XYpR6PeZSCidF32eqC5GEpXrjwHGmif0wvuGWjbJVfl1azBvgXcjARWeyGjSwVEcsJbsDX1QQ==",
+          "optional": true,
+          "requires": {
+            "@serialport/binding-mock": "^8.0.4",
+            "debug": "^4.1.1"
+          }
         }
       }
     },
@@ -4033,12 +4023,12 @@
       "optional": true
     },
     "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
       "optional": true,
       "requires": {
-        "decompress-response": "^3.3.0",
+        "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
@@ -4236,72 +4226,54 @@
       }
     },
     "tar-fs": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+      "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
       "optional": true,
       "requires": {
-        "chownr": "^1.0.1",
+        "chownr": "^1.1.1",
         "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "optional": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
       }
     },
     "tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
       "optional": true,
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
+        "bl": "^3.0.0",
+        "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "optional": true
-        },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "optional": true
+        },
         "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         }
       }
@@ -4442,12 +4414,6 @@
       "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-4.0.0.tgz",
       "integrity": "sha512-Ynn2Gsp+oCvYScQXeV+cCs7citRDilq0qDXA6tuvFwDgiYyyaq7D5vKUlAPezzZR5NDobc/QMeN6e5guOYmvxg==",
       "dev": true
-    },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "optional": true
     },
     "to-double-quotes": {
       "version": "2.0.0",
@@ -4868,7 +4834,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   "optionalDependencies": {
     "browser-serialport": "latest",
     "firmata": "^2.0.0",
-    "serialport": "^7.1.5"
+    "serialport": "^8.0.5"
   },
   "devDependencies": {
     "async": "^2.6.1",

--- a/test/board-connection.js
+++ b/test/board-connection.js
@@ -25,13 +25,11 @@ exports["Board Connection"] = {
     var calls = 0;
     var attempts = Board.Serial.attempts;
 
-    this.list = this.sandbox.stub(SerialPort, "list", function(callback) {
+    this.list = this.sandbox.stub(SerialPort, "list", () => {
       calls++;
-      process.nextTick(function() {
-        callback(null, calls === 2 ? [{
-          comName: "/dev/usb"
-        }] : []);
-      });
+      return Promise.resolve(calls === 2 ? [{
+        path: "/dev/usb"
+      }] : []);
     });
 
     var board = new Board({
@@ -63,13 +61,11 @@ exports["Board Connection"] = {
     Board.Serial.used.length = 0;
     Board.Serial.attempts[0] = 11;
 
-    this.list = this.sandbox.stub(SerialPort, "list", function(callback) {
+    this.list = this.sandbox.stub(SerialPort, "list", () => {
       calls++;
-      process.nextTick(function() {
-        callback(null, calls === 2 ? [{
-          comName: "/dev/usb"
-        }] : []);
-      });
+      return Promise.resolve(calls === 2 ? [{
+        path: "/dev/usb"
+      }] : []);
     });
 
     this.fail = this.sandbox.stub(Board.prototype, "fail", function(klass, message) {
@@ -89,15 +85,13 @@ exports["Board Connection"] = {
     var calls = 0;
     Board.Serial.used.push("/dev/ttyUSB0");
 
-    this.list = this.sandbox.stub(SerialPort, "list", function(callback) {
+    this.list = this.sandbox.stub(SerialPort, "list", () => {
       calls++;
-      process.nextTick(function() {
-        callback(null, calls === 2 ? [
-          {comName: "/dev/ttyUSB0"},
-          {comName: "/dev/ttyUSB1"},
-          {comName: "/dev/ttyUSB2"},
-        ] : []);
-      });
+      return Promise.resolve(calls === 2 ? [
+        {path: "/dev/ttyUSB0"},
+        {path: "/dev/ttyUSB1"},
+        {path: "/dev/ttyUSB2"},
+      ] : []);
     });
 
     this.info = this.sandbox.spy(Board.prototype, "info");

--- a/test/board.serial.js
+++ b/test/board.serial.js
@@ -10,9 +10,9 @@ exports["Serial"] = {
       list: [],
     };
 
-    this.sandbox.stub(SerialPort, "list", function(callback) {
-      callback(this.responses.error, this.responses.list);
-    }.bind(this));
+    this.sandbox.stub(SerialPort, "list", () => {
+      return this.responses.error ? Promise.reject(this.responses.error) : Promise.resolve(this.responses.list);
+    });
 
 
     this.sandbox.stub(Firmata, "Board", function(port, callback) {
@@ -37,12 +37,12 @@ exports["Serial"] = {
     Serial.used.push("/dev/usb");
 
     this.responses.list.push(
-      { comName: "/dev/usb" },
+      { path: "/dev/usb" },
       // This will get skipped
-      { comName: "/dev/cu.Bluetooth-Incoming-Port" },
+      { path: "/dev/cu.Bluetooth-Incoming-Port" },
       // This is the one to expect
-      { comName: "/dev/acm" },
-      { comName: "COM4" }
+      { path: "/dev/acm" },
+      { path: "COM4" }
     );
 
     Serial.detect.call(this.board, function(port) {

--- a/util/xbee.js
+++ b/util/xbee.js
@@ -50,9 +50,9 @@ if (args.help) {
 
 if (!args.portname) {
   console.error("Serial port name is required. \n `-p /dev/PORTNAME` \n Use one of the following");
-  serialport.list(function (err, data) {
+  serialport.list().then(data => {
     data.forEach(function (v) {
-      console.log("\t" + v.comName);
+      console.log("\t" + v.path);
     });
   });
   process.exit(-1);


### PR DESCRIPTION
SerialPort v8 brings support for the latest versions of node and electron. The api has had two major breaking changes. `.list()` no longer takes a callback and only returns a promise. And the `PortInfo` object now has `path` instead of `comName`.

This PR probably requires a similar upgrade to firmata https://github.com/firmata/firmata.js/pull/201

I haven't tested this PR on hardware yet.