### PR TITLE
#1658 Fixes incorrect TH02 readings due to register readings

### DIFF
--- a/lib/imu.js
+++ b/lib/imu.js
@@ -2269,21 +2269,20 @@ var Drivers = {
             // 3 bytes from 0x01.
             Promise.all([
               new Promise(function(resolve) {
-                io.i2cReadOnce(address, 0x01, 1, function(data) {
-                  resolve(data[0]);
+                const BYTES_TO_READ = 3;
+                io.i2cReadOnce(address, this.REGISTER.READ, BYTES_TO_READ, function(data) {
+                  let view = new DataView(new ArrayBuffer(BYTES_TO_READ));
+                  data.forEach(function (bytes, i) {
+                    view.setUint8(i, bytes);
+                  });
+                  resolve(view.getUint16(1));
                 });
-              }),
-              new Promise(function(resolve) {
-                io.i2cReadOnce(address, 0x02, 1, function(data) {
-                  resolve(data[0]);
-                });
-              })
-            ]).then(function(data) {
-
+              }.bind(this))
+            ]).then(function(value) {
               if (isTemperatureCycle) {
-                computed.temperature = ((uint16(data[0], data[1]) >> 2) / 32) - 50;
+                computed.temperature = ((value >> 2) / 32) - 50;
               } else {
-                computed.humidity = ((uint16(data[0], data[1]) >> 4) / 16) - 24;
+                computed.humidity = ((value >> 4) / 16) - 24;
               }
 
               if (++cycle === 2) {

--- a/lib/imu.js
+++ b/lib/imu.js
@@ -2272,8 +2272,8 @@ var Drivers = {
                 const BYTES_TO_READ = 3;
                 io.i2cReadOnce(address, this.REGISTER.READ, BYTES_TO_READ, function(data) {
                   let view = new DataView(new ArrayBuffer(BYTES_TO_READ));
-                  data.forEach(function (bytes, i) {
-                    view.setUint8(i, bytes);
+                  data.forEach(function (byte, i) {
+                    view.setUint8(i, byte);
                   });
                   resolve(view.getUint16(1));
                 });


### PR DESCRIPTION
As per the existing comments reading a single byte from `0x01`, and `0x2` was resolving to `[0,0]` so changed to read 3 bytes from `0x01` and discard the first byte. Also replaced calls to `uint16` with DataView to resolve lack of precision.