### PR TITLE
Remove support for browser-serialport

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -26,16 +26,8 @@ var Serial = {
     var maxAttempts = 10;
     // Delay (ms) before trying again to list serial connections
     var retryDelay = 400;
-    var serialport;
+    var serialport = require("serialport");
 
-    /* istanbul ignore next */
-    if (parseFloat(process.versions.nw) >= 0.13) {
-      serialport = require("browser-serialport");
-    } else {
-      serialport = require("serialport");
-    }
-
-    // console.log(require);
     // Request a list of available ports, from
     // the result set, filter for valid paths
     // via known path pattern match.


### PR DESCRIPTION
The API changes to the `serialport` module make it incompatible with the `browser-serialport` module. Until `browser-serialport` is updated to match the API of `serialport` (if ever), requiring it for NW.js no longer makes sense. In fact, leaving it there make it impossible to use Johnny-Five within NW.js.