### PR TITLE
Move to chrome-apps-serialport (instead of browser-serialport)

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -29,8 +29,8 @@ var Serial = {
     var serialport;
 
     /* istanbul ignore next */
-    if (parseFloat(process.versions.nw) >= 0.13) {
-      serialport = require("browser-serialport");
+    if (chrome && chrome.serial) {
+      serialport = require("chrome-apps-serialport").SerialPort;
     } else {
       serialport = require("serialport");
     }

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "temporal": "latest"
   },
   "optionalDependencies": {
-    "browser-serialport": "latest",
+    "chrome-apps-serialport": "^1.0.0",
     "firmata": "^2.2.0",
     "serialport": "^8.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "temporal": "latest"
   },
   "optionalDependencies": {
-    "chrome-apps-serialport": "^1.0.0",
+    "chrome-apps-serialport": "^1.0.5",
     "firmata": "^2.2.0",
     "serialport": "^8.0.5"
   },


### PR DESCRIPTION
With the changes in the API of `node-serialport` v8.x+, the `browser-serialport` is no longer usable inside Johnny-Five. For this reason, I created the `chrome-apps-serialport` module to revive support for Chrome Apps and, specifically, NW.js (which is, by definition, a Chrome App). 

This PR is pretty much harmless since `browser-serialport` is no longer working anyway. I also created a related [PR](https://github.com/firmata/firmata.js/pull/215) for Firmata.

By merging this PR, you allow users of Johnny-Five the ability to run their code inside NW.js without being forced to recompile the native `node-serialport` module, an operation which can prove to be quite complicated.