### PR TITLE
BME-280 0x76 address: Update imu.js

### DIFF
--- a/lib/imu.js
+++ b/lib/imu.js
@@ -1486,7 +1486,7 @@ var Drivers = {
 
   BME280: {
     ADDRESSES: {
-      value: [0x77]
+      value: [0x77, 0x76]
     },
     REGISTER: {
       value: {


### PR DESCRIPTION
BME280 can also sometimes operate on 0x76. Not sure if it applies to other sensors within the family, so I haven't applied it to other chips