### PR TITLE
Fixed broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ Documentation for the Johnny-Five API can be found [here](http://johnny-five.io/
 
 Need help or interested in ongoing design discussions? Join us in the [Johnny-Five Gitter Chat](https://gitter.im/rwaldron/johnny-five). You can also search for a meetup near you or find other helpful info on [NodeBots](http://nodebots.io). 
 
-
-If you just have a quick question 
 For step-by-step examples, including an electronics primer, check out [Arduino Experimenter's Guide for NodeJS](http://node-ardx.org/) by [@AnnaGerber](https://twitter.com/AnnaGerber)
 
 Here is a list of [prerequisites](https://github.com/rwaldron/johnny-five/wiki/Getting-Started#prerequisites) for Linux, OSX or Windows.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,10 @@ Documentation for the Johnny-Five API can be found [here](http://johnny-five.io/
 
 ## Guidance
 
-Need help? Ask a question on the [NodeBots Community Forum](http://forums.nodebots.io). If you just have a quick question or are interested in ongoing design discussions, join us in the [Johnny-Five Gitter Chat](https://gitter.im/rwaldron/johnny-five).
+Need help? Ask a question on the [Johnny-Five Gitter Chat](https://gitter.im/rwaldron/johnny-five). You can also search for a meetup near you or find other helpful info on [NodeBots](http://nodebots.io). 
+
+
+If you just have a quick question or are interested in ongoing design discussions, join us in 
 
 For step-by-step examples, including an electronics primer, check out [Arduino Experimenter's Guide for NodeJS](http://node-ardx.org/) by [@AnnaGerber](https://twitter.com/AnnaGerber)
 

--- a/README.md
+++ b/README.md
@@ -126,11 +126,10 @@ Documentation for the Johnny-Five API can be found [here](http://johnny-five.io/
 
 ## Guidance
 
-Need help? Ask a question on the [Johnny-Five Gitter Chat](https://gitter.im/rwaldron/johnny-five). You can also search for a meetup near you or find other helpful info on [NodeBots](http://nodebots.io). 
+Need help or interested in ongoing design discussions? Join us in the [Johnny-Five Gitter Chat](https://gitter.im/rwaldron/johnny-five). You can also search for a meetup near you or find other helpful info on [NodeBots](http://nodebots.io). 
 
 
-If you just have a quick question or are interested in ongoing design discussions, join us in 
-
+If you just have a quick question 
 For step-by-step examples, including an electronics primer, check out [Arduino Experimenter's Guide for NodeJS](http://node-ardx.org/) by [@AnnaGerber](https://twitter.com/AnnaGerber)
 
 Here is a list of [prerequisites](https://github.com/rwaldron/johnny-five/wiki/Getting-Started#prerequisites) for Linux, OSX or Windows.


### PR DESCRIPTION
Link to Nodebots.io forums is broken, and I couldn't find an alternate link for it. Seems like they're deprecated ¯\_(ツ)_/¯ 