### PR TITLE
Accelerometer: Pass board reference through to Expander

### DIFF
--- a/lib/accelerometer.js
+++ b/lib/accelerometer.js
@@ -695,6 +695,7 @@ const Controllers = {
           address,
           controller: this.controller,
           bus: this.bus,
+          board: options.board || this.board
         });
 
         // TODO: this should come from the expander


### PR DESCRIPTION
This PR fixes the bug described in #1709 by passing down the board reference given in the constructor.

Fixes https://github.com/rwaldron/johnny-five/issues/1709