### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/docs/lcd-i2c-PCF8574.md
+++ b/docs/lcd-i2c-PCF8574.md
@@ -33,7 +33,7 @@ var board = new five.Board();
 board.on("ready", function() {
 
 
-  var random = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 4).toUpperCase();
+  var random = Math.random().toString(36).replace(/[^a-z]+/g, "").slice(0, 4).toUpperCase();
 
   // Controller: PARALLEL (default)
   var p = new five.LCD({

--- a/eg/lcd-all.js
+++ b/eg/lcd-all.js
@@ -4,7 +4,7 @@ var board = new five.Board();
 board.on("ready", function() {
 
 
-  var random = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 4).toUpperCase();
+  var random = Math.random().toString(36).replace(/[^a-z]+/g, "").slice(0, 4).toUpperCase();
 
   // Controller: PARALLEL (default)
   var p = new five.LCD({

--- a/eg/lcd-i2c-PCF8574.js
+++ b/eg/lcd-i2c-PCF8574.js
@@ -4,7 +4,7 @@ var board = new five.Board();
 board.on("ready", function() {
 
 
-  var random = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 4).toUpperCase();
+  var random = Math.random().toString(36).replace(/[^a-z]+/g, "").slice(0, 4).toUpperCase();
 
   // Controller: PARALLEL (default)
   var p = new five.LCD({

--- a/lib/led/ledcontrol.js
+++ b/lib/led/ledcontrol.js
@@ -674,7 +674,7 @@ const Controllers = {
           throw new Error("The `row` method is only supported for Matrix devices");
         }
         if (typeof val === "number") {
-          val = (`0000000000000000${parseInt(val, 10).toString(2)}`).slice(-this.columns);
+          val = (`0000000000000000${parseInt(val, 10).toString(2)}`).slice(0 - (this.columns));
         }
         if (arguments.length === 2) {
           val = row;

--- a/lib/led/ledcontrol.js
+++ b/lib/led/ledcontrol.js
@@ -674,7 +674,7 @@ const Controllers = {
           throw new Error("The `row` method is only supported for Matrix devices");
         }
         if (typeof val === "number") {
-          val = (`0000000000000000${parseInt(val, 10).toString(2)}`).substr(0 - (this.columns), this.columns);
+          val = (`0000000000000000${parseInt(val, 10).toString(2)}`).slice(-this.columns);
         }
         if (arguments.length === 2) {
           val = row;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.