### PR TITLE
Assign colors, and then assign colors to keys

### DIFF
--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -434,13 +434,14 @@ class RGB {
 
 
 }
+
+RGB.colors = ["red", "green", "blue"];
+
 /**
  * For multi-property animation, must define
  * the keys to use for tween calculation.
  */
 RGB.prototype[Animation.keys] = RGB.colors;
-
-RGB.colors = ["red", "green", "blue"];
 
 RGB.ToScaledRGB = (intensity, colors) => {
   const scale = intensity / 100;

--- a/test/rgb.js
+++ b/test/rgb.js
@@ -755,6 +755,14 @@ exports["RGB"] = {
     test.done();
   },
 
+  "Animation.keys"(test) {
+    test.expect(1);
+    this.color = this.sandbox.stub(this.rgb, "color");
+    const keys = this.rgb[Animation.keys];
+    test.deepEqual(keys, ["red", "green", "blue"]);
+    test.done();
+  },
+
 };
 
 exports["10-bit RGB"] = {


### PR DESCRIPTION
@code-dot-org/johnny-five was recently updated to the latest release of its upstream in [this PR](https://github.com/code-dot-org/johnny-five/pull/12). 

@islemaster - While implementing Code.org customizations, I noticed a small bug in `lib/led/rgb.js` - `RGB.prototype[Animation.keys]` is assigned to `RGB.colors` before `RGB.colors` is assigned to an array of strings. This PR changes the order of these lines.

[jira](https://codedotorg.atlassian.net/browse/SL-358)