### PR TITLE
Add pulse method to RGB class

### DIFF
--- a/docs/led-rgb-pulse.md
+++ b/docs/led-rgb-pulse.md
@@ -1,0 +1,66 @@
+<!--remove-start-->
+
+# LED - RGB Pulse
+
+<!--remove-end-->
+
+RGB LED pulse example that fades an LED in and out repeatedly. Requires LED on pin that supports PWM (usually denoted by ~).
+
+##### RGB LED. (Arduino UNO)
+
+
+RGB LED connected to pins 6, 5, and 3 for red, green, and blue respectively.
+
+
+![docs/breadboard/led-rgb.png](breadboard/led-rgb.png)<br>
+
+Fritzing diagram: [docs/breadboard/led-rgb.fzz](breadboard/led-rgb.fzz)
+
+&nbsp;
+
+
+
+
+Run this example from the command line with:
+```bash
+node eg/led-rgb-pulse.js
+```
+
+
+```javascript
+const temporal = require("temporal");
+const { Board, Led } = require("johnny-five");
+const board = new Board();
+
+board.on("ready", () => {
+  // Initialize the RGB LED
+  const led = new Led.RGB([6, 5, 3]);
+
+  // Set color to red
+  led.color("#FF0000");
+
+// Stop and turn off the led pulse loop after
+  // 10 seconds (shown in ms)
+  board.wait(10000, () => {
+
+    // stop() terminates the interval
+    // off() shuts the led off
+    led.stop().off();
+  });
+});
+ 
+```
+
+
+&nbsp;
+
+<!--remove-start-->
+
+## License
+Copyright (c) 2012-2014 Rick Waldron <waldron.rick@gmail.com>
+Licensed under the MIT license.
+Copyright (c) 2015-2020 The Johnny-Five Contributors
+Licensed under the MIT license.
+
+<!--remove-end-->
+

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -207,6 +207,7 @@ class RGB {
         }
       },
       update: {
+        writable: true,
         value(colors) {
           const state = priv.get(this);
 
@@ -478,7 +479,9 @@ class RGB {
    */
 
   [Animation.render](frames) {
-    return this.update(frames[0]);
+    const state = priv.get(this);
+    state.value = frames[0];
+    return this.update();
   }
 
 

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -282,6 +282,11 @@ class RGB {
       };
 
       this.update(colors);
+    } else if (state.isRunning) {
+      this.stop();
+      colors = state.prev;
+      this.update(colors);
+      
     }
 
     return this;
@@ -481,7 +486,7 @@ class RGB {
   [Animation.render](frames) {
     const state = priv.get(this);
     state.value = frames[0];
-    return this.update();
+    return this.update(state.value);
   }
 
 

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -172,14 +172,14 @@ class RGB {
       intensity: 100,
       isAnode: options.isAnode || false,
       interval: null,
-      // isRunning is used to tracks whether an Animation is in progress similar to how it's used in led.js
+      // isRunning is used to track whether an Animation is in progress similar to how it's used in led.js
       isRunning: false,
       // red, green, and blue store the raw color set via .color()
       // values takes state into account, such as on/off and intensity
       values: {
         red: 255,
         green: 255,
-        blue: 255,
+        blue: 255
       }
     };
 
@@ -261,7 +261,7 @@ class RGB {
 
     this.update(update);
 
-    // store colors to state.prev for future use by on() or pulse()
+    // store colors to state.prev for future use by on()
     state.prev = update;
 
     return this;
@@ -287,13 +287,9 @@ class RGB {
   }
 
   off() {
-    const state = priv.get(this);
-
     // If it's already off, do nothing so the previous state stays intact
     /* istanbul ignore else */
     if (this.isOn) {
-      state.prev = RGB.colors.reduce((current, color) => (current[color] = state[color], current), {});
-
       this.update({
         red: 0,
         green: 0,
@@ -338,6 +334,8 @@ class RGB {
   pulse(duration, callback) {
     const state = priv.get(this);
     var currentColor = state.prev;
+
+    // Avoid traffic jams
     this.stop();
 
     const options = {
@@ -394,7 +392,7 @@ class RGB {
       state.animation.stop();
     }
 
-    state.interval = null;
+    state.interval = null; // sets isRunning to false
 
     return this;
   }
@@ -480,7 +478,7 @@ class RGB {
    */
 
   [Animation.render](frames) {
-    return this.color(frames[0]);
+    return this.update(frames[0]);
   }
 
 

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -336,6 +336,10 @@ class RGB {
    * pulse
    * @param  {Number} duration Time in ms on, time in ms off
    * @return {RGB}
+   *
+   * - or -
+   *
+   * @param  {Object} val An Animation() segment config object
    */
   pulse(duration, callback) {
     const state = priv.get(this);

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -172,6 +172,8 @@ class RGB {
       intensity: 100,
       isAnode: options.isAnode || false,
       interval: null,
+      // isRunning is used to tracks whether an Animation is in progress similar to how it's used in led.js
+      isRunning: false,
       // red, green, and blue store the raw color set via .color()
       // values takes state into account, such as on/off and intensity
       values: {
@@ -191,7 +193,7 @@ class RGB {
       },
       isRunning: {
         get() {
-          return !!state.interval;
+          return !!state.interval || state.isRunning;
         }
       },
       isAnode: {
@@ -259,6 +261,9 @@ class RGB {
 
     this.update(update);
 
+    // store colors to state.prev for future use by on() or pulse()
+    state.prev = update;
+
     return this;
   }
 
@@ -275,8 +280,6 @@ class RGB {
         blue: 255
       };
 
-      state.prev = null;
-
       this.update(colors);
     }
 
@@ -286,7 +289,7 @@ class RGB {
   off() {
     const state = priv.get(this);
 
-    // If it's already off, do nothing so the pervious state stays intact
+    // If it's already off, do nothing so the previous state stays intact
     /* istanbul ignore else */
     if (this.isOn) {
       state.prev = RGB.colors.reduce((current, color) => (current[color] = state[color], current), {});
@@ -324,6 +327,54 @@ class RGB {
       }
     }, duration || 100);
 
+    return this;
+  }
+
+  /**
+   * pulse
+   * @param  {Number} duration Time in ms on, time in ms off
+   * @return {RGB}
+   */
+  pulse(duration, callback) {
+    const state = priv.get(this);
+    var currentColor = state.prev;
+    this.stop();
+
+    const options = {
+      duration: typeof duration === "number" ? duration : 1000,
+      keyFrames: [
+        {
+          color: currentColor,
+          intensity: 0
+        },
+        {
+          color: currentColor,
+          intensity: 100
+        }
+      ],
+      metronomic: true,
+      loop: true,
+      easing: "inOutSine",
+      onloop() {
+        /* istanbul ignore else */
+        if (typeof callback === "function") {
+          callback();
+        }
+      }
+    };
+
+    if (typeof duration === "object") {
+      Object.assign(options, duration);
+    }
+
+    if (typeof duration === "function") {
+      callback = duration;
+    }
+
+    state.isRunning = true;
+
+    state.animation = state.animation || new Animation(this);
+    state.animation.enqueue(options);
     return this;
   }
 
@@ -434,13 +485,14 @@ class RGB {
 
 
 }
+
+RGB.colors = ["red", "green", "blue"];
+
 /**
  * For multi-property animation, must define
  * the keys to use for tween calculation.
  */
 RGB.prototype[Animation.keys] = RGB.colors;
-
-RGB.colors = ["red", "green", "blue"];
 
 RGB.ToScaledRGB = (intensity, colors) => {
   const scale = intensity / 100;

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -172,11 +172,18 @@ class RGB {
       intensity: 100,
       isAnode: options.isAnode || false,
       interval: null,
-      // isRunning is used to track whether an Animation is in progress similar to how it's used in led.js
+      // isRunning is used to track whether an Animation is in progress
       isRunning: false,
       // red, green, and blue store the raw color set via .color()
       // values takes state into account, such as on/off and intensity
       values: {
+        red: 255,
+        green: 255,
+        blue: 255
+      },
+      // state.prev records the last color set using color(),
+      // and is used to determine the new color when calling on() or pulse()
+      prev: {
         red: 255,
         green: 255,
         blue: 255
@@ -270,24 +277,17 @@ class RGB {
 
   on() {
     const state = priv.get(this);
-    let colors;
 
     // If it's not already on, we set them to the previous color
     if (!this.isOn) {
       /* istanbul ignore next */
-      colors = state.prev || {
-        red: 255,
-        green: 255,
-        blue: 255
-      };
-
-      this.update(colors);
+      this.update(state.prev);
     } else if (state.isRunning) {
       this.stop();
-      colors = state.prev;
-      this.update(colors);
+      this.update(state.prev);
       
     }
+
 
     return this;
   }
@@ -333,8 +333,8 @@ class RGB {
   }
 
   /**
-   * pulse
-   * @param  {Number} duration Time in ms on, time in ms off
+   * pulse - fade the RGB in and out in a loop with specified time
+   * @param  {Number} duration Time in ms that a fade in/out will elapse
    * @return {RGB}
    *
    * - or -

--- a/test/rgb.collection.js
+++ b/test/rgb.collection.js
@@ -291,22 +291,18 @@ exports["RGB.Collection"] = {
 
 
   "Animation.render": function(test) {
-    test.expect(1);
+    test.expect(3);
 
-    const rgbs = new RGB.Collection([
-      [1, 2, 3],
-      [4, 5, 6],
-    ]);
-
-    this.color = this.sandbox.stub(RGB.prototype, "color");
-
+    this.render = this.sandbox.stub(RGB.prototype, "@@render");
+    const rgbs = new RGB.Collection([ this.a, this.b ]);
     rgbs[Animation.render]([
       { red: 0xff, green: 0x00, blue: 0x00 },
       { red: 0x00, green: 0xff, blue: 0x00 },
     ]);
 
-    test.equal(this.color.callCount, 2);
+    test.equal(this.render.callCount, 2);
+    test.deepEqual(this.render.firstCall.args[0], [ { red: 255, green: 0, blue: 0 } ]);
+    test.deepEqual(this.render.secondCall.args[0], [ { red: 0, green: 255, blue: 0 } ]);
     test.done();
   },
 };
-

--- a/test/rgb.js
+++ b/test/rgb.js
@@ -749,9 +749,9 @@ exports["RGB"] = {
 
   "Animation.render"(test) {
     test.expect(1);
-    this.color = this.sandbox.stub(this.rgb, "color");
+    this.update = this.sandbox.stub(this.rgb, "update");
     this.rgb[Animation.render]([0]);
-    test.equal(this.color.callCount, 1);
+    test.equal(this.update.callCount, 1);
     test.done();
   },
 


### PR DESCRIPTION
Currently, the [Led class](https://github.com/rwaldron/johnny-five/blob/main/lib/led/led.js) contains both pulse and blink methods, but the [Rgb class](https://github.com/rwaldron/johnny-five/blob/main/lib/led/rgb.js) only contains the blink method. 

This PR adds a `pulse` method to the Rgb class. Note that the pulse method was recently [re-added](https://github.com/code-dot-org/johnny-five/pull/15) to the forked branch [`code-dot-org/johnny-five`](https://github.com/code-dot-org/johnny-five) after being updated to the latest release of upstream. The `pulse` method was first added to the Rgb class by @islemaster in [this PR](https://github.com/code-dot-org/johnny-five/pull/10).

I added the state value `isRunning` which was already a defined property in order to keep track of whether an Animation is in progress, i.e., if `pulse` is being run.  This is similar to how `isRunning` is used in `lib/led.js`.

The update method is now writeable to be able to reassign it in the unit test for Animation.render in [`test/rgb.js`](https://github.com/rwaldron/johnny-five/blob/87d2adabdf2b0c86c7e2b43c7034992171fe3dc1/test/rgb.js#L820).

More details of implementation are included in embedded comments.

## Testing
I modified unit tests in both `rgb.collection.js` and `rgb.js` as well as added new unit tests for the RGB pulse method.

## Documentation
At the request of @dtex, I added the example file `docs/led-rgb-pulse.md` and here is [documentation](https://github.com/fisher-alice/johnny-five-wiki/pull/1) about the Rgb pulse method that can be added to the johnny-five wiki.
