### PR TITLE
Modify Animation temporalTTL so that it is configurable

### DIFF
--- a/lib/animation.js
+++ b/lib/animation.js
@@ -275,7 +275,7 @@ class Animation extends Emitter {
      * accurate (by nanoseconds) but perfectly serviceable.
      * The default value is 5 seconds, but can be configured by Animation.segment options
      **/
-     let temporalTTL = typeof this.temporalTTL === 'number' ? this.temporalTTL : 0;
+     let temporalTTL = typeof this.temporalTTL === "number" ? this.temporalTTL : 5000;
 
     // If our animation runs for more than temporalTTL seconds switch to setTimeout
     this.fallBackTime = now + temporalTTL;

--- a/lib/animation.js
+++ b/lib/animation.js
@@ -8,13 +8,6 @@ let temporal;
 // Test metronomic on real animation
 // Create jquery FX like queue
 
-/**
- * The max time we want to allow a temporal animation segment to run.
- * When running, temporal can push CPU utilization to 100%. When this
- * time (in ms) is reached we will fall back to setInterval which is less
- * accurate (by nanoseconds) but perfectly serviceable.
- **/
-let temporalTTL = 5000;
 
 /**
  * Animation
@@ -275,7 +268,16 @@ class Animation extends Emitter {
     this.startTime = now - this.scaledDuration * this.progress;
     this.endTime = this.startTime + this.scaledDuration;
 
-    // If our animation runs for more than 5 seconds switch to setTimeout
+    /**
+     * temporalTTL is the max time we want to allow a temporal animation segment to run.
+     * When running, temporal can push CPU utilization to 100%. When this
+     * time (in ms) is reached we will fall back to setInterval which is less
+     * accurate (by nanoseconds) but perfectly serviceable.
+     * The default value is 5 seconds, but can be configured by Animation.segment options
+     **/
+     let temporalTTL = typeof this.temporalTTL === 'number' ? this.temporalTTL : 0;
+
+    // If our animation runs for more than temporalTTL seconds switch to setTimeout
     this.fallBackTime = now + temporalTTL;
     this.frameCount = 0;
 
@@ -530,6 +532,7 @@ Animation.Segment = class {
     this.onstop = null;
     this.oncomplete = null;
     this.onloop = null;
+    this.temporalTTL = null;
 
     if (options) {
       Object.assign(this, options);

--- a/lib/led/led.js
+++ b/lib/led/led.js
@@ -358,6 +358,7 @@ class Led {
       metronomic: true,
       loop: true,
       easing: "inOutSine",
+      temporalTTL: 0,
       onloop() {
         /* istanbul ignore else */
         if (typeof callback === "function") {

--- a/test/led.js
+++ b/test/led.js
@@ -498,6 +498,25 @@ exports["Led - PWM"] = {
     test.done();
   },
 
+  pulseTemporalTTLCallback(test) {
+    test.expect(3);
+
+    const spy = this.sandbox.spy();
+
+    this.led.pulse(300, spy);
+
+    test.equal(this.enqueue.callCount, 1);
+
+    const temporalTTL = this.enqueue.lastCall.args[0].temporalTTL;
+    const onloop = this.enqueue.lastCall.args[0].onloop;
+
+    onloop();
+
+    test.equal(temporalTTL, 0);
+    test.equal(spy.callCount, 1);
+    test.done();
+  },
+
   pulseObject(test) {
     test.expect(1);
 


### PR DESCRIPTION
This PR changes `temporalTTL` in the `Animation` class to be configurable. @dtex @islemaster 
As stated in an [existing comment](https://github.com/rwaldron/johnny-five/blob/864f9b0e278397fc6c7f354da0de0ede2d4bc389/lib/animation.js#L271-L275),  a temporal animation segment can push CPU utilization to 100%. Currently, `temporalTTL` is set to 5000 ms so that if an animation runs for more than 5 seconds, the animation switches to using setInterval which is less accurate (by nanoseconds) but "perfectly serviceable". 

I removed the `temporalTTL` constant which was originally declared and assigned outside the `Rgb` class, and added it as an `Animation.Segment` option. Thus, if it is passed as a value through the segment, then the now local variable `temporalTTL` within the `Rgb` class will be assigned this value and the `fallBackTime` will be [set accordingly](https://github.com/rwaldron/johnny-five/blob/864f9b0e278397fc6c7f354da0de0ede2d4bc389/lib/animation.js#L278-L281).

```
    let temporalTTL = typeof this.temporalTTL === "number" ? this.temporalTTL : 5000;

    // If our animation runs for more than temporalTTL seconds switch to setTimeout
    this.fallBackTime = now + temporalTTL;
```

In [this PR](https://github.com/code-dot-org/johnny-five/pull/13) that was merged to `code-dot-org/johnny-five`, I recorded the CPU performance difference of the two `temporalTTL settings` on the [Circuit Playground Express](https://www.adafruit.com/product/3333). 

I also locally tested the performance of the `pulse` and `blink` methods in the `Led` class - if no change is made to the `pulse` method in `lib/led/led.js`, then `temporalTTL` is set to 5000 in the `Animation` class. If `temporalTTL: 0` is added to the `pulse` method on line 361 in `lib/led/led.js`, then `temporalTTL` is set to 0 in the `Animation` class. The difference in performance is imperceptible. Thus, `temporalTTL` is set to 0 within the `pulse` method in the `Led` class.

## Testing
I added a unit test in `test/led.js` to check that `temporalTTL` is set to 0 when the `pulse` method is called.

## Follow-up
I posted [this PR](https://github.com/rwaldron/johnny-five/pull/1803) to add the `pulse` method to the `Rgb` class. Once it is added, `temporalTTL` can be set to 0 for its `pulse` method.
