### PR TITLE
Remove references to deprecated “axismove” event from Joystick examples

### DIFF
--- a/eg/joystick-claw.js
+++ b/eg/joystick-claw.js
@@ -19,10 +19,10 @@ board.on("ready", function() {
   // (the joystick deadzone)
   claw.to(90);
 
-  joystick.on("axismove", function() {
+  joystick.on("change", function() {
     // Open/close the claw by setting degrees according
     // to Y position of joystick.
     // limit to 170 on medium servos (ei. the servo used on the claw)
-    claw.to(Math.ceil(170 * this.fixed.y));
+    claw.to(five.Fn.scale(this.y, -1, 1, 0, 170));
   });
 });

--- a/eg/joystick-motor-led.js
+++ b/eg/joystick-motor-led.js
@@ -37,13 +37,13 @@ board.on("ready", function() {
 
   // Pushing the joystick to up position should start the motor,
   // releasing it will turn the motor off.
-  joystick.on("axismove", function() {
+  joystick.on("change", function() {
 
-    if (!motor.isOn && this.axis.y > 0.51) {
+    if (!motor.isOn && this.y > 0) {
       motor.start();
     }
 
-    if (motor.isOn && this.axis.y < 0.51) {
+    if (motor.isOn && this.y <= 0) {
       motor.stop();
     }
   });

--- a/eg/navigator-joystick.js
+++ b/eg/navigator-joystick.js
@@ -47,9 +47,9 @@ when.all(readyList, function() {
 
   servo.center();
 
-  joystick.on("axismove", function() {
+  joystick.on("change", function () {
     // 0: left, 1: center, 2: right
-    var position = Math.ceil(2 * this.fixed.x);
+    var position = Math.round(this.x + 1);
 
     // console.log( position );
 


### PR DESCRIPTION
Fixes https://github.com/rwaldron/johnny-five/issues/1810