### PR TITLE
Allow bypassing address validation in HT16K33 code to address Issue #1834

### DIFF
--- a/docs/led-digits-clock-HT16K33.md
+++ b/docs/led-digits-clock-HT16K33.md
@@ -60,6 +60,39 @@ function time(showColon) {
 
 
 
+## Additional Options
+### Specifying Addresses
+You can specify the addresses to use for the controller:
+```
+  const digits = new Led.Digits({
+    controller: "HT16K33",
+    address: 0x70,
+  });
+```
+
+### Bypassing Address Validation
+Led.Digits will ensure that you do not use the same address twice,  
+but if you use multiple Arduino boards you want to reuse the same address.  
+You can use the `skipAddressValidation` option to bypass this check:
+```
+  const digitsA = new Led.Digits({
+    controller: "HT16K33",
+    board: boards.byId("A"),
+    address: 0x70,
+    skipAddressValidation: true,
+  });
+  const digitsB = new Led.Digits({
+    controller: "HT16K33",
+    board: boards.byId("B"),
+    address: 0x70,
+    skipAddressValidation: true,
+  });
+```
+
+
+
+
+
 
 ## Additional Notes
 Learn More:

--- a/lib/led/ledcontrol.js
+++ b/lib/led/ledcontrol.js
@@ -47,6 +47,10 @@ const priv = new Map();
  * @param {Boolean} [options.colon]      Whether the device has a built in colon.
  * @param {Number}  [options.devices]    The number of connected LED devices.
  * @param {Array}   [options.addresses]  I2C addresses.
+ * @param {Boolean} [options.skipAddressValidation] Bypass address checking and incrementing.
+ *                                                  Use this when using multiple HT16K33 but at the same address
+ *                                                  on multiple Arduino or other type boards.
+ *                                                  You should also include the address or addresses when using this.
  * @param {*}       options.pins         The digital pin numbers that connect to
  *                                    data, clock, and cs connections on the controller device.
  *                                    Only for use with the default controller.

--- a/lib/led/ledcontrol.js
+++ b/lib/led/ledcontrol.js
@@ -454,12 +454,14 @@ const Controllers = {
           this.addresses = available.slice(0, state.devices);
         }
 
-        this.addresses.forEach(address => {
-          if (!addresses.has(address)) {
-            throw new Error(`Invalid HT16K33 controller address: ${address}`);
-          }
-          addresses.delete(address);
-        });
+        if (!options.skipAddressValidation) {
+          this.addresses.forEach(address => {
+            if (!addresses.has(address)) {
+              throw new Error(`Invalid HT16K33 controller address: ${address}`);
+            }
+            addresses.delete(address);
+          });
+        }
 
         this.rotation = options.rotation || 1;
         // set a default rotation that works with AdaFruit 16x8 matrix if using 16 columns


### PR DESCRIPTION
Allow adding an option called `skipAddressValidation` when calling the `Led.Digits` function to skip validating the given address and deleting them.

This will address Issue #1834 

This allows using multiple HT16K33 devices on different external boards that might all be on the same address.

This is the only option I could come up with that I feel confident won't affect any existing code that may depend on the current functionality.

I've also added documentation for the option in the place that made the most sense to me.

Please let me know if you feel this option is reasonable, and if so, if I need to add any tests for this before acceptance.
